### PR TITLE
feat: 认证支持 token 直传，适配 CI/CD 和无头场景

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -82,16 +82,17 @@ struct CallbackQuery {
 
 /// 统一的 `access_token` 获取入口。
 ///
-/// 1. config 中显式配置的 token（环境变量 / 配置文件）→ 直接使用
+/// 1. config 中显式配置的 token（环境变量 / 配置文件 / --token 注入）→ 直接使用
 /// 2. 本地 token 未过期 → 直接使用
 /// 3. 本地 token 已过期 + 有 `refresh_token` → 自动刷新
 /// 4. 刷新失败或无 token → 返回错误提示 `lx login`
 pub async fn get_access_token(config: &Config) -> Result<String> {
-    // 优先使用 config 中显式配置的 token（如环境变量传入）
+    // 优先使用 config 中显式配置的 token（--token / LX_ACCESS_TOKEN / 配置文件）
     if let Some(token) = config.mcp.access_token.clone() {
         return Ok(token);
     }
 
+    // 3. 本地 token 文件（自动刷新）
     match get_valid_token().await? {
         Some(td) => Ok(td.access_token),
         None => {

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -6,6 +6,10 @@ use std::io;
 #[command(name = "lx")]
 #[command(about = "Lexiang CLI - A command-line tool for Lexiang MCP", long_about = None)]
 pub struct Cli {
+    /// Access token for authentication (alternative to OAuth login)
+    #[arg(long = "token", global = true, env = "LX_ACCESS_TOKEN")]
+    pub token: Option<String>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,12 @@ async fn main() -> anyhow::Result<()> {
 
     // 常规命令处理
     let cli = Cli::parse();
-    let config = config::Config::load()?;
+    let mut config = config::Config::load()?;
+
+    // 将 --token / LX_ACCESS_TOKEN 注入 Config，零侵入传递
+    if let Some(ref token) = cli.token {
+        config.mcp.access_token = Some(token.clone());
+    }
 
     match cli.command {
         Some(Commands::Version) => {


### PR DESCRIPTION
Closes #10

## 变更内容

1. **`src/cmd/cli.rs`** - 新增 `--token` 全局 flag，支持 `LX_ACCESS_TOKEN` 环境变量
2. **`src/auth/mod.rs`** - `get_access_token()` 新增 token 参数，优先级：`--token`/env > config > local token file
3. **所有 cmd 模块** - 逐层传递 token 参数

## 用法

```bash
lx --token xxx space list
LX_ACCESS_TOKEN=xxx lx space list
```