### PR TITLE
feat: 增加 musl 静态编译版，消除 glibc 兼容问题

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -66,6 +66,10 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             name: linux-x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            name: linux-x86_64-musl
+            use_cross: true
           - os: macos-latest
             target: aarch64-apple-darwin
             name: macos-arm64
@@ -85,13 +89,28 @@ jobs:
           prefix-key: ci-v1
           key: ${{ matrix.target }}
 
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
       - name: Fetch dependencies
+        if: ${{ !matrix.use_cross }}
         run: cargo fetch --target ${{ matrix.target }}
 
-      - name: Build
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: ${{ !matrix.use_cross }}
         run: cargo build --target ${{ matrix.target }}
 
-      - name: Run tests
+      - name: Run tests (cross)
+        if: matrix.use_cross
+        run: cross test --target ${{ matrix.target }}
+
+      - name: Run tests (cargo)
+        if: ${{ !matrix.use_cross }}
         run: cargo test --target ${{ matrix.target }}
 
   # 依赖安全审计

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -44,6 +44,18 @@ jobs:
             artifact: lx
             use_cross: true
 
+          # Linux musl (static)
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            name: linux-x86_64-musl
+            artifact: lx
+            use_cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            name: linux-arm64-musl
+            artifact: lx
+            use_cross: true
+
           # Windows
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -172,6 +184,10 @@ jobs:
           # Linux
           cp artifacts/lx-linux-x86_64/lx-linux-x86_64 release/
           cp artifacts/lx-linux-arm64/lx-linux-arm64 release/
+          
+          # Linux musl (static)
+          cp artifacts/lx-linux-x86_64-musl/lx-linux-x86_64-musl release/
+          cp artifacts/lx-linux-arm64-musl/lx-linux-arm64-musl release/
           
           # macOS
           cp artifacts/lx-macos-x86_64/lx-macos-x86_64 release/

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -109,9 +109,13 @@ build_macos() {
 
 # 构建 Linux 目标
 build_linux() {
-    # x86_64 可以在 macOS 上用 cross 构建
+    # glibc (dynamic)
     build_target "x86_64-unknown-linux-gnu" "true" "lx-linux-x86_64"
     build_target "aarch64-unknown-linux-gnu" "true" "lx-linux-arm64"
+
+    # musl (static - no glibc dependency)
+    build_target "x86_64-unknown-linux-musl" "true" "lx-linux-x86_64-musl"
+    build_target "aarch64-unknown-linux-musl" "true" "lx-linux-arm64-musl"
 }
 
 # 构建 Windows 目标


### PR DESCRIPTION
## 关联 Issue

Closes #9

## 变更内容

1. **`scripts/build-all.sh`** - `build_linux()` 增加 musl 静态编译目标：
   - `x86_64-unknown-linux-musl` → `lx-linux-x86_64-musl`
   - `aarch64-unknown-linux-musl` → `lx-linux-arm64-musl`

2. **`.github/workflows/cli-release.yml`** - Release 构建矩阵增加 musl 目标（均使用 cross），发布产物中包含 musl 二进制

3. **`.github/workflows/cli-ci.yml`** - CI 构建矩阵增加 `linux-x86_64-musl` 目标

## 效果

- 在 CentOS 7 (glibc 2.17)、RHEL 8 等老旧服务器上不再报 `GLIBC_2.28 not found`
- musl 静态链接，零外部依赖