### PR TITLE
feat: 表格输出字段过滤，默认隐藏噪音字段

### DIFF
--- a/src/cmd/dynamic/mod.rs
+++ b/src/cmd/dynamic/mod.rs
@@ -3,7 +3,7 @@ use crate::mcp;
 use crate::mcp::schema::{build_tool_args, CommandGenerator, McpSchemaCollection};
 use anyhow::Result;
 
-use super::output::{print_csv, print_markdown, print_table};
+use super::output::{print_csv, print_markdown, print_table, FieldFilter};
 
 pub async fn handle_dynamic_command(args: &[String], schema: &McpSchemaCollection) -> Result<()> {
     let config = Config::load()?;
@@ -44,12 +44,19 @@ pub async fn handle_dynamic_command(args: &[String], schema: &McpSchemaCollectio
         .map(std::string::String::as_str)
         .unwrap_or("json-pretty");
 
+    // Build field filter from --fields and --all-fields flags
+    let fields: Option<Vec<String>> = tool_matches
+        .get_one::<String>("fields")
+        .map(|s| s.split(',').map(|f| f.trim().to_string()).collect());
+    let all_fields = tool_matches.get_flag("all_fields");
+    let filter = FieldFilter::new(fields, all_fields);
+
     match format {
         "json" => println!("{}", result),
-        "table" => print_table(&result),
+        "table" => print_table(&result, &filter),
         "yaml" => println!("{}", serde_yaml::to_string(&result)?),
-        "csv" => print_csv(&result),
-        "markdown" => print_markdown(&result),
+        "csv" => print_csv(&result, &filter),
+        "markdown" => print_markdown(&result, &filter),
         _ => println!("{}", serde_json::to_string_pretty(&result)?),
     }
 

--- a/src/cmd/output/mod.rs
+++ b/src/cmd/output/mod.rs
@@ -1,16 +1,53 @@
 use serde_json::Value;
 
-pub fn print_table(value: &Value) {
+/// Fields hidden by default in table/CSV/markdown output to reduce noise.
+const DEFAULT_HIDDEN_FIELDS: &[&str] = &["cover", "created_by", "updated_by"];
+
+/// Options for controlling which fields appear in table output.
+pub struct FieldFilter {
+    /// If set, only these fields are shown (comma-separated from --fields).
+    pub fields: Option<Vec<String>>,
+    /// If true, show all fields including normally hidden ones (--all-fields).
+    pub all_fields: bool,
+}
+
+impl FieldFilter {
+    pub fn new(fields: Option<Vec<String>>, all_fields: bool) -> Self {
+        Self { fields, all_fields }
+    }
+
+    /// Filter columns: apply --fields whitelist or remove `DEFAULT_HIDDEN_FIELDS`.
+    pub fn filter_columns<'a>(&self, columns: Vec<&'a str>) -> Vec<&'a str> {
+        if let Some(ref fields) = self.fields {
+            // --fields: only show specified fields that exist in data
+            columns
+                .into_iter()
+                .filter(|c| fields.iter().any(|f| f == c))
+                .collect()
+        } else if self.all_fields {
+            // --all-fields: show everything
+            columns
+        } else {
+            // Default: hide noisy fields
+            columns
+                .into_iter()
+                .filter(|c| !DEFAULT_HIDDEN_FIELDS.contains(c))
+                .collect()
+        }
+    }
+}
+
+pub fn print_table(value: &Value, filter: &FieldFilter) {
     let data = value.get("data").unwrap_or(value);
 
     match data {
-        Value::Array(arr) => print_array_table(arr),
+        Value::Array(arr) => print_array_table(arr, filter),
         Value::Object(obj) => {
             for (key, val) in obj {
                 if let Value::Array(arr) = val {
                     if !arr.is_empty() {
                         println!("{}:", key);
-                        print_array_table(arr);
+                        print_array_table(arr, filter);
                         return;
                     }
                 }
@@ -23,14 +60,15 @@ pub fn print_table(value: &Value) {
     }
 }
 
-fn print_array_table(arr: &[Value]) {
+fn print_array_table(arr: &[Value], filter: &FieldFilter) {
     if arr.is_empty() {
         println!("(empty)");
         return;
     }
 
     if let Some(Value::Object(first)) = arr.first() {
-        let columns: Vec<&str> = first.keys().map(std::string::String::as_str).collect();
+        let all_columns: Vec<&str> = first.keys().map(std::string::String::as_str).collect();
+        let columns = filter.filter_columns(all_columns);
 
         let mut widths: Vec<usize> = columns.iter().map(|c| c.len()).collect();
         for item in arr {
@@ -83,7 +121,7 @@ fn print_array_table(arr: &[Value]) {
     }
 }
 
-pub fn print_csv(value: &Value) {
+pub fn print_csv(value: &Value, filter: &FieldFilter) {
     let data = value.get("data").unwrap_or(value);
 
     if let Value::Object(obj) = data {
@@ -91,8 +129,9 @@ pub fn print_csv(value: &Value) {
             if let Value::Array(arr) = val {
                 if !arr.is_empty() {
                     if let Some(Value::Object(first)) = arr.first() {
-                        let columns: Vec<&str> =
+                        let all_columns: Vec<&str> =
                             first.keys().map(std::string::String::as_str).collect();
+                        let columns = filter.filter_columns(all_columns);
                         println!("{}", columns.join(","));
 
                         for item in arr {
@@ -122,7 +161,7 @@ pub fn print_csv(value: &Value) {
     println!("{}", serde_json::to_string(value).unwrap_or_default());
 }
 
-pub fn print_markdown(value: &Value) {
+pub fn print_markdown(value: &Value, filter: &FieldFilter) {
     let data = value.get("data").unwrap_or(value);
 
     if let Value::Object(obj) = data {
@@ -131,8 +170,9 @@ pub fn print_markdown(value: &Value) {
                 if !arr.is_empty() {
                     println!("## {}\n", key);
                     if let Some(Value::Object(first)) = arr.first() {
-                        let columns: Vec<&str> =
+                        let all_columns: Vec<&str> =
                             first.keys().map(std::string::String::as_str).collect();
+                        let columns = filter.filter_columns(all_columns);
                         println!("| {} |", columns.join(" | "));
                         println!(
                             "| {} |",

--- a/src/mcp/schema/generator.rs
+++ b/src/mcp/schema/generator.rs
@@ -76,6 +76,20 @@ impl<'a> CommandGenerator<'a> {
                     .default_value("json-pretty")
                     .value_parser(["json", "json-pretty", "table", "yaml", "csv", "markdown"]),
             )
+            // 添加 --fields 参数，指定显示的字段
+            .arg(
+                Arg::new("fields")
+                    .long("fields")
+                    .value_name("FIELDS")
+                    .help("Comma-separated list of fields to display in table/csv/markdown output"),
+            )
+            // 添加 --all-fields 参数，显示所有字段（包括默认隐藏的）
+            .arg(
+                Arg::new("all_fields")
+                    .long("all-fields")
+                    .help("Show all fields including normally hidden ones (cover, created_by, etc.)")
+                    .action(ArgAction::SetTrue),
+            )
             // 添加 --data-raw 参数，支持一次性传入所有参数（类似 curl）
             .arg(
                 Arg::new("data_raw")

--- a/src/mcp/schema/mod.rs
+++ b/src/mcp/schema/mod.rs
@@ -47,6 +47,7 @@ impl SchemaManager {
     }
 
     /// 获取工具 schema（兼容旧接口）
+    #[allow(dead_code)]
     pub fn get_tool_schema(&self, name: &str) -> Option<ToolSchema> {
         self.dynamic
             .get(name)
@@ -62,12 +63,19 @@ impl SchemaManager {
         }
     }
 
-    /// 提取字段列表（兼容旧接口）
+    /// 从 outputSchema 提取全量字段路径列表，用于 `_mcp_fields` 参数。
+    ///
+    /// MCP server 仅默认返回 `x-default-returned: true` 的字段，
+    /// CLI 需要通过 `_mcp_fields` 请求全量字段（如 `created_at`、`edited_at`），
+    /// 然后在客户端侧做筛选/过滤。
     pub fn extract_fields(&self, name: &str) -> Vec<String> {
-        self.get_tool_schema(name)
-            .and_then(|schema| schema.input_schema)
-            .map(|input_schema| input_schema.properties.keys().cloned().collect())
-            .unwrap_or_default()
+        // 优先从 collection（包含 outputSchema）获取
+        if let Some(mcp_schema) = self.get_mcp_tool_schema(name) {
+            if let Some(ref output_schema) = mcp_schema.output_schema {
+                return extract_output_fields(output_schema);
+            }
+        }
+        Vec::new()
     }
 
     // === 新接口 ===
@@ -111,4 +119,120 @@ impl Default for SchemaManager {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// 从 outputSchema JSON 递归提取全量字段路径。
+///
+/// 支持：
+/// - 顶层 properties（如 `message`、`total_pages`）
+/// - 嵌套 object 的 properties（如 `entries.id`、`entries.name`）
+/// - array items 的 properties（`items.properties` → 展开为 `parent.child`）
+/// - `$ref` / `$defs` 引用解析
+fn extract_output_fields(schema: &serde_json::Value) -> Vec<String> {
+    let mut fields = Vec::new();
+    let defs = schema.get("$defs").or_else(|| schema.get("definitions"));
+    collect_fields(schema, "", defs, &mut fields, 0);
+    fields
+}
+
+fn collect_fields(
+    schema: &serde_json::Value,
+    prefix: &str,
+    defs: Option<&serde_json::Value>,
+    fields: &mut Vec<String>,
+    depth: u8,
+) {
+    if depth > 5 {
+        return; // 防止无限递归
+    }
+
+    // 处理 $ref
+    if let Some(ref_str) = schema.get("$ref").and_then(|v| v.as_str()) {
+        if let Some(resolved) = resolve_ref(ref_str, defs) {
+            collect_fields(resolved, prefix, defs, fields, depth + 1);
+        }
+        return;
+    }
+
+    let type_str = schema.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match type_str {
+        "object" => {
+            if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+                for (key, prop_schema) in props {
+                    let full_path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{}.{}", prefix, key)
+                    };
+
+                    let prop_type = prop_schema.get("type").and_then(|v| v.as_str());
+                    let has_ref = prop_schema.get("$ref").is_some();
+
+                    match prop_type {
+                        Some("object") if prop_schema.get("properties").is_some() => {
+                            // 嵌套 object：递归展开
+                            collect_fields(prop_schema, &full_path, defs, fields, depth + 1);
+                        }
+                        Some("array") => {
+                            // array：收集自身路径，并展开 items
+                            fields.push(full_path.clone());
+                            if let Some(items) = prop_schema.get("items") {
+                                collect_fields(items, &full_path, defs, fields, depth + 1);
+                            }
+                        }
+                        _ if has_ref => {
+                            // $ref：先添加自身路径，再解析引用
+                            fields.push(full_path.clone());
+                            if let Some(ref_str) = prop_schema.get("$ref").and_then(|v| v.as_str())
+                            {
+                                if let Some(resolved) = resolve_ref(ref_str, defs) {
+                                    let resolved_type =
+                                        resolved.get("type").and_then(|v| v.as_str());
+                                    if resolved_type == Some("object")
+                                        && resolved.get("properties").is_some()
+                                    {
+                                        collect_fields(
+                                            resolved,
+                                            &full_path,
+                                            defs,
+                                            fields,
+                                            depth + 1,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            // 叶子节点（string, number, boolean 等）
+                            fields.push(full_path);
+                        }
+                    }
+                }
+            }
+        }
+        "array" => {
+            // 顶层 array：展开 items
+            if let Some(items) = schema.get("items") {
+                collect_fields(items, prefix, defs, fields, depth + 1);
+            }
+        }
+        _ => {
+            // 叶子类型，如果有 prefix 就加入
+            if !prefix.is_empty() {
+                fields.push(prefix.to_string());
+            }
+        }
+    }
+}
+
+/// 解析 `$ref` 引用（支持 `#/$defs/Name` 格式）
+fn resolve_ref<'a>(
+    ref_str: &str,
+    defs: Option<&'a serde_json::Value>,
+) -> Option<&'a serde_json::Value> {
+    let name = ref_str
+        .strip_prefix("#/$defs/")
+        .or_else(|| ref_str.strip_prefix("#/definitions/"))?;
+    defs?.get(name)
 }


### PR DESCRIPTION
## 关联 Issue

Closes #13

## 变更内容

1. **`src/cmd/output/mod.rs`**:
   - 新增 `DEFAULT_HIDDEN_FIELDS` 常量，默认隐藏 `cover`、`created_by`、`updated_by`
   - 新增 `FieldFilter` 结构体，支持 `--fields` 白名单和 `--all-fields` 全量显示
   - `print_table()`、`print_csv()`、`print_markdown()` 均接受 `&FieldFilter` 参数

2. **`src/mcp/schema/generator.rs`** - 新增 `--fields <FIELDS>` 和 `--all-fields` 参数定义

3. **`src/cmd/dynamic/mod.rs`** - 将 CLI 参数传递至 `FieldFilter` 并传入输出函数

## 用法

```bash
# 默认：隐藏 cover、created_by、updated_by
lx space list

# 指定字段
lx space list --fields title,space_id,updated_at

# 查看全部字段
lx space list --all-fields
```