### PR TITLE
feat: git clone/pull 构造包含远端信息的 commit message

### DIFF
--- a/src/cmd/git/mod.rs
+++ b/src/cmd/git/mod.rs
@@ -83,7 +83,16 @@ async fn handle_clone(config: &Config, space_id: String, path: String) -> Result
 
     worktree::EntriesManager::save(&worktree_path, &entries_map)?;
 
-    repo.add_and_commit("Initial clone")?;
+    let commit_message = format!(
+        "Initial clone from remote\n\nSpace: {} ({})\nRoot entry: {}\nFetched: {} folders, {} pages, {} files",
+        space_name,
+        space_id,
+        root_entry_id,
+        stats.folders_created,
+        stats.pages_pulled,
+        stats.files_pulled
+    );
+    repo.add_and_commit(&commit_message)?;
 
     let mut registry = WorktreeRegistry::load()?;
     registry.register(WorktreeRecord {
@@ -266,7 +275,15 @@ async fn handle_pull(config: &Config) -> Result<()> {
 
     worktree::EntriesManager::save(&worktree_path, &entries_map)?;
 
-    let commit_id = repo.add_and_commit("Pull from remote")?;
+    let commit_message = format!(
+        "Pull from remote\n\nSpace: {} ({})\nPulled: {} folders, {} pages, {} files",
+        wt_config.space_name,
+        wt_config.space_id,
+        stats.folders_created,
+        stats.pages_pulled,
+        stats.files_pulled
+    );
+    let commit_id = repo.add_and_commit(&commit_message)?;
     println!("Committed: {}", &commit_id[..8]);
 
     println!();

--- a/src/cmd/git/workspace.rs
+++ b/src/cmd/git/workspace.rs
@@ -178,7 +178,16 @@ async fn handle_add(
 
     worktree::EntriesManager::save(&worktree_path, &entries_map)?;
 
-    let commit_id = repo.add_and_commit("Initial checkout")?;
+    let commit_message = format!(
+        "Initial checkout from remote\n\nSpace: {} ({})\nRoot entry: {}\nFetched: {} folders, {} pages, {} files",
+        space_name,
+        space_id,
+        root_entry_id,
+        stats.folders_created,
+        stats.pages_pulled,
+        stats.files_pulled
+    );
+    let commit_id = repo.add_and_commit(&commit_message)?;
     wt_config.set_remote_snapshot(commit_id);
 
     wt_config.save(&worktree_path)?;
@@ -561,7 +570,15 @@ async fn handle_pull(config: &Config) -> Result<()> {
 
     let mut repo = Repository::open(&worktree_path)?;
     if repo.has_uncommitted_changes()? {
-        let commit_id = repo.add_and_commit("Pull from remote")?;
+        let commit_message = format!(
+            "Pull from remote\n\nSpace: {} ({})\nPulled: {} folders, {} pages, {} files",
+            wt_config.space_name,
+            wt_config.space_id,
+            stats.folders_created,
+            stats.pages_pulled,
+            stats.files_pulled
+        );
+        let commit_id = repo.add_and_commit(&commit_message)?;
         println!("Committed: {}", &commit_id[..8]);
     }
 


### PR DESCRIPTION
Closes #15

## 变更

- lx git clone 初始提交包含 Space 名称/ID、root entry、拉取统计
- lx git pull 提交包含 Space 名称/ID、增量拉取统计
- lx worktree add 同步改造

Agent 执行 lx git log 可理解工作区历史来源。