### PR TITLE
fix: 清理 fetch-doc 文档与实现的不一致

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,7 +55,6 @@
 ├─────────────────────────────────────────┤
 │  Layer 2: Legacy Commands               │
 │  - lx lexiang search                    │
-│  - lx lexiang fetch-doc                 │
 │  - 静态代码实现                         │
 ├─────────────────────────────────────────┤
 │  Layer 1: Raw MCP Commands              │
@@ -231,8 +230,8 @@ cargo build --release
 {
   "_comment": "Unlisted-but-callable tools. tool_names is config-as-code.",
   "tool_names": [
-    "search_kb_fetch_doc",
-    "search_kb_create_doc"
+    "entry_delete_entry",
+    "file_list_revisions"
   ],
   "tools": {
     // ← 由 sync-unlisted 自动填充，勿手动编辑

--- a/src/cmd/dynamic/mod.rs
+++ b/src/cmd/dynamic/mod.rs
@@ -99,7 +99,6 @@ pub fn print_help_with_dynamic_commands(schema: Option<&McpSchemaCollection>) {
     println!("Commands:");
 
     println!("  search         Search in knowledge base (shortcut for 'lexiang search')");
-    println!("  fetch-doc      Fetch a document (shortcut for 'lexiang fetch-doc')");
     println!("  lexiang        Lexiang namespace commands");
     println!("  mcp            MCP operations");
     println!("  tools          Tools schema management");


### PR DESCRIPTION
Closes #12

- 删除 help 文本中不存在的 fetch-doc 快捷方式
- 删除 DEVELOPMENT.md 中 fetch-doc 引用
- 替换 unlisted.json 示例中不存在的 tool 名（search_kb_fetch_doc → entry_delete_entry）