### PR TITLE
feat: add 'lx tools schema' command for OpenClaw integration

### DIFF
--- a/openclaw/src/schema.ts
+++ b/openclaw/src/schema.ts
@@ -92,8 +92,8 @@ export async function loadSchema(): Promise<McpSchemaCollection | null> {
  */
 export async function loadCachedSchema(): Promise<McpSchemaCollection | null> {
   try {
-    // lx 会把 schema 缓存到 ~/.lexiang/cache/schema.json
-    const result = await execLx(['tools', 'list', '--format', 'json']);
+    // 使用 lx tools schema 获取完整 schema JSON
+    const result = await execLx(['tools', 'schema']);
     if (result.exitCode !== 0) {
       return null;
     }

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -120,7 +120,12 @@ pub enum ToolsCommands {
         /// Category name (e.g., "team", "space", "entry")
         #[arg(short, long)]
         category: Option<String>,
+        /// Output format (table, json)
+        #[arg(short, long, default_value = "table")]
+        format: String,
     },
+    /// Output full schema JSON (for `OpenClaw` and other integrations)
+    Schema,
     /// Sync schema from MCP Server and write to schemas/lexiang.json (development self-bootstrap)
     SyncEmbedded,
     /// Fetch unlisted tool schemas from MCP Server based on `tool_names` in schemas/unlisted.json

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -20,8 +20,8 @@ pub use mcp::{call_tool, list_tools};
 pub use sh::{build_shell, exec_command, start_repl};
 pub use skill::{handle_generate, handle_install, handle_status, handle_uninstall, handle_update};
 pub use tools::{
-    handle_categories, handle_list, handle_sync, handle_sync_embedded, handle_sync_unlisted,
-    handle_version,
+    handle_categories, handle_list, handle_schema, handle_sync, handle_sync_embedded,
+    handle_sync_unlisted, handle_version,
 };
 pub use update::{
     auto_check_update, handle_check as handle_update_check, handle_list as handle_update_list,

--- a/src/cmd/tools/mod.rs
+++ b/src/cmd/tools/mod.rs
@@ -46,12 +46,20 @@ pub fn handle_version() -> Result<()> {
     Ok(())
 }
 
-pub fn handle_list(category: Option<&str>) -> Result<()> {
+pub fn handle_list(category: Option<&str>, format: &str) -> Result<()> {
     let manager = SchemaManager::load_from_runtime();
+    let is_json = format == "json" || format == "json-pretty";
 
     if let Some(cat) = category {
         let tools = manager.get_tools_by_namespace(cat);
-        if tools.is_empty() {
+        if is_json {
+            // JSON 输出: 返回该分类下的 tools 数组
+            let output = serde_json::json!({
+                "category": cat,
+                "tools": tools
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if tools.is_empty() {
             println!(
                 "No tools found in category '{}'. Run 'lx tools sync' first.",
                 cat
@@ -65,13 +73,34 @@ pub fn handle_list(category: Option<&str>) -> Result<()> {
         }
     } else {
         let categories = manager.get_categories();
-        if categories.is_empty() {
+        if is_json {
+            // JSON 输出: 返回完整的 McpSchemaCollection
+            if let Some(coll) = manager.get_collection() {
+                println!("{}", serde_json::to_string_pretty(coll)?);
+            } else {
+                println!("{{}}");
+            }
+        } else if categories.is_empty() {
             println!("No categories found. Run 'lx tools sync' first.");
         } else {
             let names: Vec<_> = categories.iter().map(|c| c.name.as_str()).collect();
             println!("Available categories: {}", names.join(", "));
             println!("\nUse 'lx tools list --category <name>' to see tools in a category.");
         }
+    }
+
+    Ok(())
+}
+
+/// 输出完整 schema JSON (用于 `OpenClaw` 等集成)
+pub fn handle_schema() -> Result<()> {
+    let manager = SchemaManager::load_from_runtime();
+
+    if let Some(coll) = manager.get_collection() {
+        println!("{}", serde_json::to_string_pretty(coll)?);
+    } else {
+        eprintln!("No schema found. Run 'lx tools sync' first.");
+        std::process::exit(1);
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,10 @@ async fn main() -> anyhow::Result<()> {
             cmd::ToolsCommands::Sync => cmd::handle_sync(&config).await?,
             cmd::ToolsCommands::Categories => cmd::handle_categories()?,
             cmd::ToolsCommands::Version => cmd::handle_version()?,
-            cmd::ToolsCommands::List { category } => cmd::handle_list(category.as_deref())?,
+            cmd::ToolsCommands::List { category, format } => {
+                cmd::handle_list(category.as_deref(), &format)?;
+            }
+            cmd::ToolsCommands::Schema => cmd::handle_schema()?,
             cmd::ToolsCommands::SyncEmbedded => cmd::handle_sync_embedded(&config).await?,
             cmd::ToolsCommands::SyncUnlisted => cmd::handle_sync_unlisted(&config).await?,
         },

--- a/src/mcp/schema/mod.rs
+++ b/src/mcp/schema/mod.rs
@@ -102,6 +102,11 @@ impl SchemaManager {
             .unwrap_or_default()
     }
 
+    /// 获取完整的 schema collection
+    pub fn get_collection(&self) -> Option<&McpSchemaCollection> {
+        self.collection.as_ref()
+    }
+
     /// 设置 schema collection
     #[allow(dead_code)]
     pub fn set_collection(&mut self, collection: McpSchemaCollection) {


### PR DESCRIPTION
Fixes #42

## 变更内容

- 添加 `lx tools schema` 命令，输出完整的 McpSchemaCollection JSON
- 给 `lx tools list` 添加 `--format` 参数支持 JSON 输出
- 添加 `SchemaManager::get_collection()` 方法
- 更新 OpenClaw 使用 `lx tools schema` 加载工具 schema

## 验证

```bash
$ lx tools schema | jq '.tools | keys | length'
49
```
