### PR TITLE
fix: 修正 VSCode 更新检查的 GitHub 仓库所有者

### DIFF
--- a/packages/app-vscode/src/services/update-checker.ts
+++ b/packages/app-vscode/src/services/update-checker.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 
 // ── 常量 ──────────────────────────────────────────────────────────────────
 
-const GITHUB_OWNER = 'nicholasniu';
+const GITHUB_OWNER = 'tencent-lexiang';
 const GITHUB_REPO = 'lexiang-cli';
 const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=20`;
 const VSCODE_TAG_PREFIX = 'vscode-v';


### PR DESCRIPTION
## 问题

VSCode 插件更新检查的 `GITHUB_OWNER` 硬编码为 `nicholasniu`，而实际 release 发布在 `tencent-lexiang/lexiang-cli`，导致 API 请求到错误的仓库，永远无法检测到新版本。

## 修复

将 `GITHUB_OWNER` 从 `nicholasniu` 改为 `tencent-lexiang`，与实际 release 地址一致。

Release 下载地址示例:
```
https://github.com/tencent-lexiang/lexiang-cli/releases/download/vscode-v0.0.1/lefs-vscode-0.0.1.vsix
```