### PR TITLE
fix(openclaw): auto-download lx during onboarding

### DIFF
--- a/packages/openclaw/src/__tests__/index.test.ts
+++ b/packages/openclaw/src/__tests__/index.test.ts
@@ -13,6 +13,10 @@ vi.mock('../cli.js', () => ({
   downloadLxBinary: vi.fn(),
   execLx: vi.fn(),
   execLxJson: vi.fn(),
+  getManualInstallHelp: vi.fn(() => ({
+    command: 'cargo install lexiang-cli',
+    releasesUrl: 'https://github.com/test/repo/releases',
+  })),
 }));
 
 vi.mock('../schema.js', () => ({
@@ -21,7 +25,7 @@ vi.mock('../schema.js', () => ({
   registerCoreTools: vi.fn(),
 }));
 
-import { isLxAvailable, getLxBinary, downloadLxBinary } from '../cli.js';
+import { isLxAvailable, getLxBinary, downloadLxBinary, getManualInstallHelp } from '../cli.js';
 import { loadCachedSchema, registerToolsFromSchema, registerCoreTools } from '../schema.js';
 
 describe('Plugin Registration', () => {
@@ -230,6 +234,20 @@ describe('lx-status Tool', () => {
     expect(downloadLxBinary).toHaveBeenCalled();
     expect(result.details.success).toBe(true);
     expect(result.details.installed).toBe(true);
+  });
+
+  it('should include GitHub Releases link when install fails', async () => {
+    vi.mocked(downloadLxBinary).mockRejectedValue(new Error('download failed'));
+    vi.mocked(getManualInstallHelp).mockReturnValue({
+      command: 'cargo install lexiang-cli',
+      releasesUrl: 'https://github.com/test/repo/releases',
+    });
+
+    const result = await statusExecute('id', { action: 'install' });
+
+    expect(result.details.success).toBe(false);
+    expect(result.details.hint).toContain('cargo install lexiang-cli');
+    expect(result.details.hint).toContain('https://github.com/test/repo/releases');
   });
 
   it('should sync schema', async () => {

--- a/packages/openclaw/src/__tests__/onboarding-flow.test.ts
+++ b/packages/openclaw/src/__tests__/onboarding-flow.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Onboarding flow integration tests
+ */
+
+// @ts-nocheck - Test file uses vitest globals
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let cliInstalled = false;
+
+vi.mock('../cli.js', () => ({
+  isLxAvailable: vi.fn(() => cliInstalled),
+  downloadLxBinary: vi.fn(async () => {
+    cliInstalled = true;
+    return '/tmp/lx';
+  }),
+  execLx: vi.fn(async () => ({
+    stdout: 'lexiang-cli v0.1.1',
+    stderr: '',
+    exitCode: 0,
+  })),
+  getManualInstallHelp: vi.fn(() => ({
+    command: 'cargo install lexiang-cli',
+    repoUrl: 'https://github.com/test/repo',
+    releasesUrl: 'https://github.com/test/repo/releases',
+  })),
+}));
+
+import { lexiangOnboardingAdapter } from '../onboarding.js';
+
+function createPrompter(overrides?: Partial<Record<'confirm' | 'text' | 'note' | 'select', any>>) {
+  return {
+    note: vi.fn().mockResolvedValue(undefined),
+    confirm: vi.fn().mockResolvedValue(true),
+    text: vi.fn().mockResolvedValue('eyJtest-token'),
+    select: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('Onboarding flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cliInstalled = false;
+    delete process.env.LEXIANG_ACCESS_TOKEN;
+  });
+
+  it('fails onboarding when auto-download fails', async () => {
+    const prompter = createPrompter();
+    const { downloadLxBinary } = await import('../cli.js');
+    vi.mocked(downloadLxBinary).mockRejectedValueOnce(new Error('network down'));
+
+    const result = await lexiangOnboardingAdapter.configure({
+      cfg: {},
+      prompter,
+    });
+
+    expect(result.success).toBe(false);
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining('自动安装失败'),
+      '安装失败',
+    );
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining('https://github.com/test/repo/releases'),
+      '安装失败',
+    );
+  });
+
+  it('auto-downloads CLI and completes onboarding without install confirmation', async () => {
+    const initialStatus = await lexiangOnboardingAdapter.getStatus({ cfg: {} });
+    expect(initialStatus.configured).toBe(false);
+
+    const prompter = createPrompter();
+
+    const result = await lexiangOnboardingAdapter.configure({
+      cfg: {},
+      prompter,
+    });
+
+    expect(result.success).toBe(true);
+    expect(prompter.confirm).not.toHaveBeenCalled();
+
+    const finalStatus = await lexiangOnboardingAdapter.getStatus({ cfg: result.cfg });
+    expect(finalStatus.configured).toBe(true);
+  });
+
+  it('completes onboarding after installing CLI and saving token', async () => {
+    const prompter = createPrompter();
+
+    const result = await lexiangOnboardingAdapter.configure({
+      cfg: {},
+      prompter,
+    });
+
+    expect(result.success).toBe(true);
+
+    const finalStatus = await lexiangOnboardingAdapter.getStatus({ cfg: result.cfg });
+    expect(finalStatus.configured).toBe(true);
+
+    const cfg = result.cfg as any;
+    expect(cfg.plugins.entries['lexiang-cli'].enabled).toBe(true);
+    expect(cfg.plugins.entries['lexiang-cli'].config.accessToken).toBe('eyJtest-token');
+  });
+});

--- a/packages/openclaw/src/__tests__/onboarding.test.ts
+++ b/packages/openclaw/src/__tests__/onboarding.test.ts
@@ -11,9 +11,14 @@ vi.mock('../cli.js', () => ({
   isLxAvailable: vi.fn(),
   downloadLxBinary: vi.fn(),
   execLx: vi.fn(),
+  getManualInstallHelp: vi.fn(() => ({
+    command: 'cargo install lexiang-cli',
+    repoUrl: 'https://github.com/test/repo',
+    releasesUrl: 'https://github.com/test/repo/releases',
+  })),
 }));
 
-import { isLxAvailable, downloadLxBinary, execLx } from '../cli.js';
+import { isLxAvailable, downloadLxBinary, execLx, getManualInstallHelp } from '../cli.js';
 import { lexiangOnboardingAdapter } from '../onboarding.js';
 
 describe('Onboarding Adapter', () => {
@@ -78,7 +83,7 @@ describe('Onboarding Adapter', () => {
   });
 
   describe('configure', () => {
-    it('should install CLI when not available', async () => {
+    it('should auto-download CLI when not available', async () => {
       vi.mocked(isLxAvailable).mockReturnValue(false);
       vi.mocked(downloadLxBinary).mockResolvedValue('/path/to/lx');
       vi.mocked(execLx).mockResolvedValue({
@@ -86,10 +91,15 @@ describe('Onboarding Adapter', () => {
         stderr: '',
         exitCode: 0,
       });
+      vi.mocked(getManualInstallHelp).mockReturnValue({
+        command: 'cargo install lexiang-cli',
+        repoUrl: 'https://github.com/test/repo',
+        releasesUrl: 'https://github.com/test/repo/releases',
+      });
 
       const mockPrompter = {
         note: vi.fn(),
-        confirm: vi.fn().mockResolvedValue(true),
+        confirm: vi.fn(),
         text: vi.fn().mockResolvedValue('eyJtest-token'),
         select: vi.fn(),
       };
@@ -100,6 +110,7 @@ describe('Onboarding Adapter', () => {
       });
 
       expect(downloadLxBinary).toHaveBeenCalled();
+      expect(mockPrompter.confirm).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
     });
 

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -40,6 +40,12 @@ interface CliConfigFile {
   version?: string;
 }
 
+export interface ManualInstallHelp {
+  command: string;
+  repoUrl?: string;
+  releasesUrl?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -78,6 +84,17 @@ function loadCliConfig(): CliConfigFile {
   } catch {
     return { repo: '' };
   }
+}
+
+export function getManualInstallHelp(config: CliConfig = {}): ManualInstallHelp {
+  const cliConfig = loadCliConfig();
+  const repo = config.repo ?? cliConfig.repo;
+
+  return {
+    command: 'cargo install lexiang-cli',
+    repoUrl: repo ? `https://github.com/${repo}` : undefined,
+    releasesUrl: repo ? `https://github.com/${repo}/releases` : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -9,7 +9,7 @@
 
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 
-import { execLx, getLxBinary, isLxAvailable, downloadLxBinary } from './cli.js';
+import { execLx, getLxBinary, isLxAvailable, downloadLxBinary, getManualInstallHelp } from './cli.js';
 import { lexiangOnboardingAdapter } from './onboarding.js';
 import { loadCachedSchema, registerToolsFromSchema, registerCoreTools } from './schema.js';
 import { formatToolResult } from './tools/helpers.js';
@@ -73,10 +73,16 @@ const plugin = {
               version: result.stdout.trim(),
             });
           } catch (err) {
+            const manualInstall = getManualInstallHelp();
+            const hintParts = [`Manual install: ${manualInstall.command}`];
+            if (manualInstall.releasesUrl) {
+              hintParts.push(`GitHub Releases: ${manualInstall.releasesUrl}`);
+            }
+
             return formatToolResult({
               success: false,
               error: String(err),
-              hint: 'Manual install: cargo install lexiang-cli',
+              hint: hintParts.join(' | '),
             });
           }
         }

--- a/packages/openclaw/src/onboarding.ts
+++ b/packages/openclaw/src/onboarding.ts
@@ -6,7 +6,7 @@
  * 2. 配置 Access Token
  */
 
-import { isLxAvailable, downloadLxBinary, execLx } from './cli.js';
+import { isLxAvailable, downloadLxBinary, execLx, getManualInstallHelp } from './cli.js';
 
 // ---------------------------------------------------------------------------
 // Types (inline to avoid SDK version issues)
@@ -140,40 +140,30 @@ export const lexiangOnboardingAdapter: ChannelOnboardingAdapter = {
         '安装 Lexiang CLI',
       );
 
-      const shouldInstall = await prompter.confirm({
-        message: '是否自动下载安装 lx CLI？',
-        initialValue: true,
-      });
+      try {
+        console.log('正在下载 lx CLI...');
+        const binaryPath = await downloadLxBinary();
+        console.log(`✓ 已安装到 ${binaryPath}`);
 
-      if (shouldInstall) {
-        try {
-          console.log('正在下载 lx CLI...');
-          const binaryPath = await downloadLxBinary();
-          console.log(`✓ 已安装到 ${binaryPath}`);
-
-          const version = await getLxVersion();
-          if (version) {
-            console.log(`  版本: ${version}`);
-          }
-        } catch (err) {
-          await prompter.note(
-            [
-              `自动安装失败: ${err}`,
-              '',
-              '请手动安装：',
-              '  cargo install lexiang-cli',
-              '',
-              '或从 GitHub Releases 下载预编译版本。',
-            ].join('\n'),
-            '安装失败',
-          );
-          return { success: false, cfg: next as never };
+        const version = await getLxVersion();
+        if (version) {
+          console.log(`  版本: ${version}`);
         }
-      } else {
+      } catch (err) {
+        const manualInstall = getManualInstallHelp();
+
         await prompter.note(
-          '跳过 CLI 安装。请稍后手动安装 lx CLI 后再使用乐享相关功能。',
-          '提示',
+          [
+            `自动安装失败: ${err}`,
+            '',
+            '请手动安装：',
+            `  ${manualInstall.command}`,
+            ...(manualInstall.repoUrl ? ['', `GitHub 仓库：${manualInstall.repoUrl}`] : []),
+            ...(manualInstall.releasesUrl ? [`GitHub Releases：${manualInstall.releasesUrl}`] : []),
+          ].join('\n'),
+          '安装失败',
         );
+        return { success: false, cfg: next as never };
       }
     } else {
       const version = await getLxVersion();


### PR DESCRIPTION
## Summary
- auto-download lx during OpenClaw onboarding when the CLI is missing
- remove the extra install confirmation and keep failure handling explicit
- add onboarding flow tests for auto-download success and failure

Fixes #53.

## Verification
- pnpm vitest run
- pnpm lint
- pnpm build