### PR TITLE
feat(block): MDX Notion spec alignment & legacy code cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "uuid",
  "walkdir",
 ]
 
@@ -3586,6 +3587,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/lx/Cargo.toml
+++ b/crates/lx/Cargo.toml
@@ -64,6 +64,7 @@ thiserror = "1"
 
 # MDX parsing (markdown-rs with MDX extensions)
 markdown = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/lx/src/cmd/block/mod.rs
+++ b/crates/lx/src/cmd/block/mod.rs
@@ -482,15 +482,15 @@ async fn handle_get(service: &BlockService, matches: &clap::ArgMatches) -> Resul
 
     match format {
         "mdx" | "markdown" => {
-            // 提取 block 数据并转换为 MDX
-            use crate::service::block::converter::render_blocks_to_markdown;
+            // 使用本地 MDX 引擎（完整语义保真）
+            use crate::service::block::BlockService;
             let block_data = result
                 .get("data")
                 .or_else(|| result.get("block"))
                 .cloned()
                 .unwrap_or(result.clone());
             let block = crate::service::block::Block::from_json(&block_data);
-            let mdx = render_blocks_to_markdown(&[block]);
+            let mdx = BlockService::block_to_mdx_local(&block)?;
             print!("{}", mdx);
         }
         _ => {
@@ -709,27 +709,33 @@ async fn handle_convert(_service: &BlockService, matches: &clap::ArgMatches) -> 
     };
 
     match (input_type, to) {
-        ("mdx" | "markdown", "blocks" | "json") => {
-            // MDX → blocks: 使用服务端转换
-            // 这里我们用本地 MDX 解析器如果有的话，否则提示需要 MCP
-            eprintln!("Note: MDX→blocks conversion requires MCP server call.");
-            eprintln!("Use 'lx mcp call block_convert_content_to_blocks' or set up service.");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&serde_json::json!({
-                    "input_type": input_type,
-                    "output_type": to,
-                    "content_preview": raw.chars().take(200).collect::<String>(),
-                    "note": "Use lx mcp call block_convert_content_to_blocks for server-side conversion"
-                }))?
-            );
+        ("mdx", "blocks" | "json") => {
+            // MDX → blocks: 使用本地引擎（不经过 MCP）
+            use crate::service::block::BlockService;
+            let json = BlockService::mdx_to_blocks_local(&raw)?;
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        ("mdx", "mdx" | "markdown") => {
+            // MDX → MDX (验证 round-trip): parse → emit
+            use crate::service::block::{mdx::emit_mdx, mdx::parse_mdx};
+            let doc = parse_mdx(&raw)?;
+            print!("{}", emit_mdx(&doc));
         }
         ("blocks" | "json", "mdx" | "markdown") => {
-            // blocks → MDX: 本地转换
+            // blocks → MDX: 本地引擎
+            use crate::service::block::BlockService;
             let parsed: serde_json::Value = serde_json::from_str(&raw)?;
-            let block = crate::service::block::Block::from_json(&parsed);
-            use crate::service::block::converter::render_blocks_to_markdown;
-            print!("{}", render_blocks_to_markdown(&[block]));
+            // 支持单个 block 对象或数组
+            if let Some(arr) = parsed.as_array() {
+                let blocks: Vec<crate::service::block::Block> = arr
+                    .iter()
+                    .map(crate::service::block::Block::from_json)
+                    .collect();
+                print!("{}", BlockService::blocks_to_mdx_local(&blocks)?);
+            } else {
+                let block = crate::service::block::Block::from_json(&parsed);
+                print!("{}", BlockService::block_to_mdx_local(&block)?);
+            }
         }
         _ => {
             // 同类型或未知，直接输出格式化的结果
@@ -757,8 +763,13 @@ async fn handle_export(service: &BlockService, matches: &clap::ArgMatches) -> Re
             let tree = service.get_tree(block_id, true).await?;
             println!("{}", serde_json::to_string_pretty(&tree)?);
         }
+        "mdx" => {
+            // 使用本地 MDX 引擎（完整语义保真：Callout/ColumnList/Table/Todo 等）
+            let mdx = service.export_as_mdx(block_id).await?;
+            print!("{}", mdx);
+        }
         _ => {
-            // mdx / markdown
+            // markdown 兜底（旧链路，简单渲染）
             let md = service.blocks_to_markdown(block_id).await?;
             print!("{}", md);
         }
@@ -773,13 +784,30 @@ async fn handle_import(service: &BlockService, matches: &clap::ArgMatches) -> Re
     let chunk_size = *matches.get_one::<usize>("chunk-size").unwrap();
 
     let content = std::fs::read_to_string(file)?;
-    service
-        .import_markdown(block_id, &content, chunk_size)
-        .await?;
-    println!(
-        "\u{2713} Imported from {} (chunk_size={})",
-        file, chunk_size
-    );
+
+    // 检测内容类型：MDX 使用本地引擎，Markdown 走旧 MCP 链路
+    let content_type = detect_content_type(&content);
+
+    match content_type {
+        "mdx" => {
+            // 本地引擎：MDX → DocIR → ir_to_descendant() → 分批插入
+            service.import_mdx(block_id, &content, chunk_size).await?;
+            println!(
+                "\u{2713} Imported from {} using local MDX engine (chunk_size={})",
+                file, chunk_size
+            );
+        }
+        _ => {
+            // 旧链路：Markdown → MCP 服务端转换
+            service
+                .import_markdown(block_id, &content, chunk_size)
+                .await?;
+            println!(
+                "\u{2713} Imported from {} via MCP server (chunk_size={})",
+                file, chunk_size
+            );
+        }
+    }
 
     Ok(())
 }
@@ -1025,8 +1053,13 @@ async fn resolve_descendant(
             // 已经是 JSON，直接使用
             Ok(serde_json::from_str(raw)?)
         }
-        "mdx" | "markdown" => {
-            // MDX/Markdown → blocks（调用 MCP 服务端转换）
+        "mdx" => {
+            // MDX → blocks（本地引擎，不经过 MCP 转换器）
+            use crate::service::block::BlockService;
+            BlockService::mdx_to_blocks_local(raw)
+        }
+        "markdown" => {
+            // 旧链路：Markdown → MCP 服务端转换
             service.markdown_to_blocks(raw).await
         }
         _ => service.markdown_to_blocks(raw).await,
@@ -1051,8 +1084,13 @@ async fn resolve_update_data(
             let parsed: serde_json::Value = serde_json::from_str(raw)?;
             Ok(parsed)
         }
-        "mdx" | "markdown" => {
-            // 先转为 blocks 再包装
+        "mdx" => {
+            // MDX → blocks（本地引擎，不经过 MCP 转换器）
+            use crate::service::block::BlockService;
+            BlockService::mdx_to_blocks_local(raw)
+        }
+        "markdown" => {
+            // 旧链路：先转为 blocks 再包装
             let descendant = service.markdown_to_blocks(raw).await?;
             Ok(descendant)
         }

--- a/crates/lx/src/service/block/adapter.rs
+++ b/crates/lx/src/service/block/adapter.rs
@@ -1123,7 +1123,8 @@ mod verify_ids {
         );
 
         // Write to file for inspection
-        std::fs::write("/tmp/ir_output_test.json", &json_str).expect("write failed");
+        let tmp_path = std::env::temp_dir().join("ir_output_test.json");
+        std::fs::write(&tmp_path, &json_str).expect("write failed");
 
         let children = json["children"].as_array().unwrap();
         for (i, c) in children.iter().enumerate() {

--- a/crates/lx/src/service/block/adapter.rs
+++ b/crates/lx/src/service/block/adapter.rs
@@ -14,7 +14,10 @@ use crate::service::block::types::{Block, BlockType};
 /// Map `NodeType` to standard `block_type` string (consistent with `BlockType::as_str`)
 fn node_type_to_block_type(nt: &NodeType) -> String {
     match nt {
-        NodeType::Paragraph => "paragraph".into(),
+        NodeType::Paragraph
+        | NodeType::Text
+        | NodeType::Link { .. }
+        | NodeType::MathBlock { .. } => "paragraph".into(),
         NodeType::Heading { level } => format!("h{}", level),
         NodeType::BlockQuote => "quote".into(),
         NodeType::Callout { .. } => "callout".into(),
@@ -35,7 +38,6 @@ fn node_type_to_block_type(nt: &NodeType) -> String {
         NodeType::SmartSheet { .. } => "smartsheet".into(),
         NodeType::Attachment { .. } => "attachment".into(),
         NodeType::Video { .. } => "video".into(),
-        NodeType::Text | NodeType::Link { .. } | NodeType::MathBlock { .. } => "paragraph".into(),
         NodeType::Document => "document".into(),
     }
 }

--- a/crates/lx/src/service/block/adapter.rs
+++ b/crates/lx/src/service/block/adapter.rs
@@ -1,7 +1,7 @@
 //! `DocIR` ↔ Block Adapter
 //!
 //! Converts between `DocIR` (intermediate representation) and MCP Block JSON.
-//! Aligned with xiaokeai MCP Server's `block_create_block_descendant` schema.
+//! Aligned with Notion Enhanced Markdown Spec.
 //!
 //! - `ir_to_descendant()`: `DocIR` → full descendant JSON for MCP API
 //! - `block_to_ir()`: Block JSON (from MCP) → `DocIR`
@@ -11,39 +11,71 @@
 use super::ir::{InlineStyle, Node, NodeType};
 use crate::service::block::types::{Block, BlockType};
 
+/// Map `NodeType` to standard `block_type` string (consistent with `BlockType::as_str`)
+fn node_type_to_block_type(nt: &NodeType) -> String {
+    match nt {
+        NodeType::Paragraph => "paragraph".into(),
+        NodeType::Heading { level } => format!("h{}", level),
+        NodeType::BlockQuote => "quote".into(),
+        NodeType::Callout { .. } => "callout".into(),
+        NodeType::ColumnList => "column_list".into(),
+        NodeType::Column { .. } => "column".into(),
+        NodeType::Table => "table".into(),
+        NodeType::TableRow => "table_row".into(),
+        NodeType::TableCell { .. } => "table_cell".into(),
+        NodeType::BulletedList => "bullet_list".into(),
+        NodeType::NumberedList => "numbered_list".into(),
+        NodeType::Task { .. } => "task".into(),
+        NodeType::CodeBlock { .. } => "code".into(),
+        NodeType::Divider => "divider".into(),
+        NodeType::Image { .. } => "image".into(),
+        NodeType::Toggle => "toggle".into(),
+        NodeType::Mermaid { .. } => "mermaid".into(),
+        NodeType::PlantUml { .. } => "plantuml".into(),
+        NodeType::SmartSheet { .. } => "smartsheet".into(),
+        NodeType::Attachment { .. } => "attachment".into(),
+        NodeType::Video { .. } => "video".into(),
+        NodeType::Text | NodeType::Link { .. } | NodeType::MathBlock { .. } => "paragraph".into(),
+        NodeType::Document => "document".into(),
+    }
+}
+
 // ============================================================
 // Forward: DocIR → Block JSON (for block_create_block_descendant)
 // ============================================================
 
 /// Convert `DocIR` node tree to a complete descendant JSON structure.
 ///
-/// Output format matches MCP `block_create_block_descendant` schema:
-/// ```json
-/// {
-///   "block_type": "p",
-///   "content": { ... },
-///   "children": [ ... ]
-/// }
-/// ```
+/// Output uses standard `block_type` names consistent with `BlockType::as_str`.
 pub fn ir_to_descendant(node: &Node) -> serde_json::Value {
-    match &node.node_type {
-        NodeType::Document => ir_document(node),
-        _ => ir_block(node),
-    }
+    ir_block(node)
 }
 
 fn ir_document(node: &Node) -> serde_json::Value {
     let children: Vec<serde_json::Value> = node.children.iter().map(ir_block).collect();
     serde_json::json!({
         "type": "document",
+        "id": node.id.clone().unwrap_or_else(gen_block_id),
         "content": {},
         "children": children,
     })
 }
 
-/// Core conversion: single `DocIR` node → MCP Block JSON
+/// Generate a UUID v4 block id (google/uuid compatible)
+fn gen_block_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Resolve block ID: use Node.id if set (from original Block JSON), otherwise generate UUID v4
+fn resolve_id(node: &Node) -> String {
+    node.id.clone().unwrap_or_else(gen_block_id)
+}
+
+/// Core conversion: single `DocIR` node → MCP Block JSON (with auto-generated id)
 fn ir_block(node: &Node) -> serde_json::Value {
-    match &node.node_type {
+    let block_id = resolve_id(node);
+
+    let mut result = match &node.node_type {
         NodeType::Paragraph => ir_paragraph(&node.children),
         NodeType::Heading { level } => ir_heading(*level, &node.children),
         NodeType::BlockQuote => ir_quote(&node.children),
@@ -70,8 +102,9 @@ fn ir_block(node: &Node) -> serde_json::Value {
             vertical_align.as_deref(),
             &node.children,
         ),
+        NodeType::Toggle => ir_toggle(&node.children),
 
-        // === Leaf types ===
+        // === Leaf types (no children) ===
         NodeType::BulletedList => ir_bullet_list(&node.children),
         NodeType::NumberedList => ir_numbered_list(&node.children),
         NodeType::Task { done, .. } => ir_task(*done, node.task_name.as_deref(), &node.children),
@@ -92,7 +125,6 @@ fn ir_block(node: &Node) -> serde_json::Value {
             *height,
             align.as_deref(),
         ),
-        NodeType::Toggle => ir_toggle(&node.children),
         NodeType::Mermaid { .. } | NodeType::PlantUml { .. } => ir_diagram(
             &node.node_type,
             node.diagram_content.as_deref().unwrap_or(""),
@@ -119,8 +151,21 @@ fn ir_block(node: &Node) -> serde_json::Value {
             // Wrap as paragraph
             ir_paragraph(std::slice::from_ref(node))
         }
-        NodeType::Document => ir_document(node),
-    }
+        NodeType::Document => {
+            let children: Vec<serde_json::Value> = node.children.iter().map(ir_block).collect();
+            serde_json::json!({
+                "type": "document",
+                "id": node.id.clone().unwrap_or_else(gen_block_id),
+                "content": {},
+                "children": children,
+            })
+        }
+    };
+
+    // Inject unique block ID
+    result["id"] = serde_json::json!(block_id);
+
+    result
 }
 
 // ---- Inline text conversion (MCP elements[] format) ----
@@ -218,24 +263,27 @@ fn ir_inline_element(node: &Node) -> Vec<serde_json::Value> {
 // ---- Block type converters (matching real MCP schema) ----
 
 fn ir_paragraph(inlines: &[Node]) -> serde_json::Value {
-    serde_json::json!({
-        "block_type": "p",
+    let result = serde_json::json!({
+        "block_type": "paragraph",
         "content": {
             "text": { "elements": ir_inlines(inlines) }
         },
         "children": []
-    })
+    });
+    // Block-level color would go here if MCP schema supports it
+    result
 }
 
 fn ir_heading(level: u8, inlines: &[Node]) -> serde_json::Value {
     let type_str = format!("h{}", level);
-    serde_json::json!({
+    let result = serde_json::json!({
         "block_type": type_str,
         "content": {
             "text": { "elements": ir_inlines(inlines) }
         },
         "children": []
-    })
+    });
+    result
 }
 
 fn ir_quote(inlines: &[Node]) -> serde_json::Value {
@@ -271,7 +319,7 @@ fn ir_callout(color: Option<&str>, icon: Option<&str>, children: &[Node]) -> ser
 
 fn ir_bullet_list(inlines: &[Node]) -> serde_json::Value {
     serde_json::json!({
-        "block_type": "bulleted_list",
+        "block_type": "bullet_list",
         "content": {
             "text": { "elements": ir_inlines(inlines) }
         },
@@ -530,7 +578,8 @@ pub fn block_to_ir(blocks: &[Block]) -> Node {
 }
 
 fn block_node_to_ir(block: &Block) -> Node {
-    match &block.block_type {
+    let id = block.id.clone();
+    let mut node = match &block.block_type {
         BlockType::Paragraph => {
             let inlines = extract_elements(block.content.get("text"));
             Node::paragraph(inlines)
@@ -662,7 +711,13 @@ fn block_node_to_ir(block: &Block) -> Node {
         BlockType::Attachment => Node::plain_text(block.text.as_deref().unwrap_or("[attachment]")),
         BlockType::Video => Node::plain_text(block.text.as_deref().unwrap_or("[video]")),
         BlockType::Unknown(s) => Node::plain_text(format!("[unknown block type: {s}]")),
+    };
+
+    // Preserve original block id from JSON
+    if !id.is_empty() {
+        node.id = Some(id);
     }
+    node
 }
 
 /// Extract inline Nodes from MCP `content.text.elements[]` or fallback to plain string
@@ -704,61 +759,6 @@ fn extract_element(value: &serde_json::Value) -> Option<Node> {
         inline_style,
         ..Default::default()
     })
-}
-
-/// Legacy: extract from old text[] format (backward compat)
-fn extract_element_legacy(value: &serde_json::Value) -> Option<Node> {
-    let t = value.get("type")?.as_str()?;
-    match t {
-        "text" => {
-            let text = value.get("text")?.as_str()?.to_string();
-            let bold = value.get("bold")?.as_bool().unwrap_or(false);
-            let italic = value
-                .get("italic")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false);
-            let strike = value
-                .get("strikeThrough")
-                .or_else(|| value.get("strikethrough"))
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false);
-            let underline = value
-                .get("underline")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false);
-
-            let style = if bold || italic || strike || underline {
-                Some(InlineStyle {
-                    bold,
-                    italic,
-                    underline,
-                    strike_through: strike,
-                    ..Default::default()
-                })
-            } else {
-                None
-            };
-
-            Some(Node {
-                node_type: NodeType::Text,
-                text: Some(text),
-                inline_style: style,
-                ..Default::default()
-            })
-        }
-        "mention" => Some(Node::plain_text(
-            value
-                .get("text")?
-                .as_str()
-                .unwrap_or("@unknown")
-                .to_string(),
-        )),
-        "equation" => Some(Node::plain_text(format!(
-            "${}$",
-            value.get("text")?.as_str().unwrap_or("")
-        ))),
-        _ => None,
-    }
 }
 
 fn extract_text_style(style_obj: &serde_json::Value) -> InlineStyle {
@@ -810,7 +810,7 @@ mod tests {
     fn test_ir_paragraph_to_json() {
         let node = Node::paragraph(vec![Node::plain_text("hello "), Node::bold("world")]);
         let json = ir_block(&node);
-        assert_eq!(json["block_type"], "p");
+        assert_eq!(json["block_type"], "paragraph");
         assert_eq!(
             json["content"]["text"]["elements"]
                 .as_array()
@@ -856,7 +856,7 @@ mod tests {
         assert_eq!(json["content"]["color"], "red");
         assert_eq!(json["content"]["icon"], "🚧");
         // Children should contain the paragraph inside
-        assert_eq!(json["children"][0]["block_type"], "p");
+        assert_eq!(json["children"][0]["block_type"], "paragraph");
     }
 
     #[test]
@@ -908,7 +908,7 @@ mod tests {
         let json = ir_block(&col);
         assert_eq!(json["block_type"], "column");
         assert_eq!(json["content"]["width_ratio"], 0.5);
-        assert_eq!(json["children"][0]["block_type"], "p");
+        assert_eq!(json["children"][0]["block_type"], "paragraph");
     }
 
     #[test]
@@ -926,7 +926,7 @@ mod tests {
         )])]);
         let json = ir_block(&node);
         assert_eq!(json["block_type"], "toggle");
-        assert_eq!(json["children"][0]["block_type"], "p");
+        assert_eq!(json["children"][0]["block_type"], "paragraph");
     }
 
     #[test]
@@ -939,7 +939,7 @@ mod tests {
         assert_eq!(json["type"], "document");
         assert_eq!(json["children"].as_array().unwrap().len(), 2);
         assert_eq!(json["children"][0]["block_type"], "h1");
-        assert_eq!(json["children"][1]["block_type"], "p");
+        assert_eq!(json["children"][1]["block_type"], "paragraph");
     }
 
     #[test]
@@ -948,10 +948,10 @@ mod tests {
 
 This is **important**.
 
-<Callout icon="🚧" borderColor="red">
+<callout icon="🚧" color="red">
 ## Warning
 Check before proceeding.
-</Callout>
+</callout>
 
 - [ ] Task A
 - [x] Task B
@@ -978,20 +978,14 @@ fn main() {}
 
         // Paragraph with bold
         let para = &children[1];
-        assert_eq!(para["block_type"], "p");
+        assert_eq!(para["block_type"], "paragraph");
         let inlines = para["content"]["text"]["elements"].as_array().unwrap();
         assert_eq!(inlines.len(), 3); // "This is ", bold("important"), "."
         assert_eq!(inlines[1]["text_run"]["text_style"]["bold"], true);
 
-        // Callout as container type
-        let callout_idx = children.iter().position(|c| {
-            c["block_type"] == "callout"
-                || (c["block_type"] == "quote" && c["content"].get("callout").is_some())
-        });
-        assert!(
-            callout_idx.is_some(),
-            "should have a callout/quote+callout block"
-        );
+        // Callout as container type (Notion format)
+        let callout_idx = children.iter().position(|c| c["block_type"] == "callout");
+        assert!(callout_idx.is_some(), "should have a <callout> block");
 
         // Todos
         let todos: Vec<_> = children
@@ -1085,5 +1079,155 @@ fn main() {}
         // Callout should have inner child
         assert_eq!(co.children.len(), 1);
         assert_eq!(co.children[0].node_type, NodeType::Paragraph);
+    }
+}
+#[cfg(test)]
+mod verify_ids {
+    use super::ir_to_descendant;
+    use crate::service::block::ir::Node;
+
+    #[test]
+    fn test_all_blocks_have_id() {
+        let doc = Node::document(vec![
+            Node::heading(1, vec![Node::plain_text("H1")]),
+            Node::callout(
+                Some("red"),
+                Some("🚧"),
+                vec![Node::paragraph(vec![Node::plain_text("inner")])],
+            ),
+            Node::toggle(vec![
+                Node::heading(2, vec![Node::bold("Toggle H2")]),
+                Node::paragraph(vec![Node::plain_text("toggle body")]),
+            ]),
+        ]);
+        let json = ir_to_descendant(&doc);
+
+        // Print actual structure for manual inspection
+        let json_str = serde_json::to_string_pretty(&json).unwrap();
+        // Use assert to force-print
+        let doc_id = json.get("id").and_then(|v| v.as_str()).unwrap_or("MISSING");
+        // UUID v4 format: 36 chars, contains hyphens, starts with hex
+        assert_eq!(
+            doc_id.len(),
+            36,
+            "UUID should be 36 chars, got len={}: {}",
+            doc_id.len(),
+            doc_id
+        );
+        assert!(
+            doc_id.contains('-') && doc_id.chars().all(|c| c.is_ascii_hexdigit() || c == '-'),
+            "Invalid UUID: {}",
+            doc_id
+        );
+
+        // Write to file for inspection
+        std::fs::write("/tmp/ir_output_test.json", &json_str).expect("write failed");
+
+        let children = json["children"].as_array().unwrap();
+        for (i, c) in children.iter().enumerate() {
+            let bid = c.get("id").and_then(|v| v.as_str()).unwrap_or("NO_ID");
+            let bt = c.get("block_type").and_then(|v| v.as_str()).unwrap_or("?");
+            let kids = c
+                .get("children")
+                .and_then(|v| v.as_array())
+                .map(std::vec::Vec::len)
+                .unwrap_or(0);
+            eprintln!("  [{}] {} [{}] children={}", bid, bt, i + 1, kids);
+            assert!(c.get("id").is_some(), "child[{}] missing id", i);
+
+            // Verify Callout inner child has id too
+            if bt == "callout" {
+                if let Some(inner) = c.get("children").and_then(|v| v.as_array()) {
+                    for (j, ic) in inner.iter().enumerate() {
+                        let iid = ic.get("id").and_then(|v| v.as_str()).unwrap_or("NO_ID");
+                        let ibt = ic.get("block_type").and_then(|v| v.as_str()).unwrap_or("?");
+                        eprintln!("      [{}] {} [{}.{}]", iid, ibt, i + 1, j + 1);
+                        assert!(ic.get("id").is_some(), "callout inner[{}] missing id", j);
+                    }
+                }
+            }
+            // Verify Toggle inner children have id
+            if bt == "toggle" {
+                if let Some(inner) = c.get("children").and_then(|v| v.as_array()) {
+                    for (j, ic) in inner.iter().enumerate() {
+                        let iid = ic.get("id").and_then(|v| v.as_str()).unwrap_or("NO_ID");
+                        let ibt = ic.get("block_type").and_then(|v| v.as_str()).unwrap_or("?");
+                        eprintln!("      [{}] {} [{}.{}]", iid, ibt, i + 1, j + 1);
+                        assert!(ic.get("id").is_some(), "toggle inner[{}] missing id", j);
+                    }
+                }
+            }
+        }
+    }
+}
+#[cfg(test)]
+mod uuid_roundtrip {
+    use super::super::adapter::{block_to_ir, ir_to_descendant};
+    use super::super::ir::Node;
+    use crate::service::block::{Block, BlockType};
+
+    #[test]
+    fn test_block_to_ir_preserves_id() {
+        let block = Block {
+            id: "12345678".to_string(),
+            block_type: BlockType::H2,
+            text: Some("Test Heading".to_string()),
+            content: serde_json::json!({"text": "Test Heading"}),
+            children: vec![],
+        };
+        let doc = block_to_ir(std::slice::from_ref(&block));
+        // Original numeric id should be preserved in Node
+        assert_eq!(doc.children[0].id.as_deref(), Some("12345678"));
+
+        // Round-trip back to JSON should keep same id
+        let json = ir_to_descendant(&doc);
+        assert_eq!(json["children"][0]["id"].as_str().unwrap(), "12345678");
+        println!("Original id preserved: {}", json["children"][0]["id"]);
+    }
+
+    #[test]
+    fn test_new_blocks_get_uuid() {
+        let doc = Node::document(vec![Node::plain_text("new")]);
+        let json = ir_to_descendant(&doc);
+        let doc_id = json["id"].as_str().unwrap();
+        // Should be UUID v4 format (36 chars)
+        assert_eq!(doc_id.len(), 36, "Expected UUID v4 format, got: {}", doc_id);
+        println!("Generated UUID: {}", doc_id);
+    }
+}
+#[cfg(test)]
+mod emitter_id_test {
+    use super::super::adapter::block_to_ir;
+    use crate::service::block::mdx::emit_mdx;
+    use crate::service::block::{Block, BlockType};
+
+    #[test]
+    fn test_emitter_outputs_block_id() {
+        // Block with numeric original id
+        let block = Block {
+            id: "98765".to_string(),
+            block_type: BlockType::Callout,
+            text: None,
+            content: serde_json::json!({"callout": true, "color": "red", "icon": "🚧"}),
+            children: vec![],
+        };
+
+        let doc = block_to_ir(std::slice::from_ref(&block));
+        assert_eq!(doc.children[0].id.as_deref(), Some("98765"));
+
+        // After Notion alignment: id is NOT emitted in MDX output (Notion format uses no id attr)
+        // IR preserves the id internally, but emitter does not render it
+        let mdx = emit_mdx(&doc);
+        println!("MDX output:\n{}", mdx);
+        assert!(
+            mdx.contains("<callout"),
+            "MDX should contain <callout>, got:\n{}",
+            mdx
+        );
+        assert!(
+            mdx.contains("color=\"red\""),
+            "MDX should contain color=red, got:\n{}",
+            mdx
+        );
     }
 }

--- a/crates/lx/src/service/block/converter.rs
+++ b/crates/lx/src/service/block/converter.rs
@@ -1,12 +1,21 @@
-//! 内容转换：markdown ↔ blocks
+//! 内容转换：markdown / mdx ↔ blocks
+//!
+//! 两条链路:
+//!   - **Markdown 链路**: 调 MCP `block_convert_content_to_blocks`，服务端转换
+//!   - **MDX 链路**: 本地 MDX parser → `DocIR` → `ir_to_descendant()` → 直接构造 Block JSON
 
+use super::adapter::{block_to_ir, ir_to_descendant};
+use super::mdx::{emit_mdx, parse_mdx};
 use super::types::{Block, BlockType};
 use super::BlockService;
 use anyhow::Result;
 
+// ============================================================
+//  Markdown 渲染（纯函数，用于 git 导出等场景）
+// ============================================================
+
 /// 纯函数：Block 树转 markdown（不需要 MCP 调用）
 ///
-/// 从 cmd/git/mod.rs 的 `blocks_to_markdown` 提取并增强，
 /// 支持强类型 Block 和嵌套子块递归。
 pub fn render_blocks_to_markdown(blocks: &[Block]) -> String {
     let mut lines = Vec::new();
@@ -196,6 +205,94 @@ impl BlockService {
         }
 
         Ok(())
+    }
+
+    // ============================================================
+    //  新链路：本地 MDX 引擎（不经过 MCP 转换器）
+    // ============================================================
+
+    /// Block 树 → MDX 文本（本地引擎，完整语义保真）
+    ///
+    /// 流程: Block JSON → `block_to_ir()` → `DocIR` → `emit_mdx()` → String
+    pub fn blocks_to_mdx_local(blocks: &[Block]) -> Result<String> {
+        let doc = block_to_ir(blocks);
+        let mdx = emit_mdx(&doc);
+        Ok(mdx)
+    }
+
+    /// 单个 Block → MDX（便捷方法）
+    pub fn block_to_mdx_local(block: &Block) -> Result<String> {
+        Self::blocks_to_mdx_local(std::slice::from_ref(block))
+    }
+
+    /// MDX 文本 → 完整 descendant JSON（本地引擎）
+    ///
+    /// 流程: MDX string → `parse_mdx()` → `DocIR` → `ir_to_descendant()` → JSON
+    ///
+    /// 返回的 JSON 可直接传给 `block_create_block_descendant` 的 `descendant` 参数。
+    /// **不调用 MCP** `block_convert_content_to_blocks`。
+    pub fn mdx_to_blocks_local(mdx_str: &str) -> Result<serde_json::Value> {
+        let doc = parse_mdx(mdx_str)?;
+        let json = ir_to_descendant(&doc);
+        Ok(json)
+    }
+
+    /// MDX 文本导入到指定父块（本地解析 + 分批插入）
+    ///
+    /// 与 `import_markdown` 类似，但使用本地 MDX parser 而非 MCP 转换。
+    pub async fn import_mdx(
+        &self,
+        parent_id: &str,
+        mdx_str: &str,
+        chunk_size: usize,
+    ) -> Result<()> {
+        let descendant = Self::mdx_to_blocks_local(mdx_str)?;
+
+        // 获取 children 数组
+        let children = descendant
+            .get("children")
+            .and_then(|c| c.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        if children.is_empty() {
+            // 没有子块，直接创建整个 descendant
+            self.mcp
+                .call_tool(
+                    "block_create_block_descendant",
+                    serde_json::json!({
+                        "block_id": parent_id,
+                        "descendant": descendant,
+                    }),
+                )
+                .await?;
+            return Ok(());
+        }
+
+        // 分块插入
+        for chunk in children.chunks(chunk_size) {
+            let chunk_descendant = serde_json::json!({
+                "children": chunk,
+            });
+
+            self.mcp
+                .call_tool(
+                    "block_create_block_descendant",
+                    serde_json::json!({
+                        "block_id": parent_id,
+                        "descendant": chunk_descendant,
+                    }),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// 获取整个文档为 MDX（通过 `get_tree` + 本地转换）
+    pub async fn export_as_mdx(&self, root_id: &str) -> Result<String> {
+        let tree = self.get_tree(root_id, true).await?;
+        Self::blocks_to_mdx_local(&tree.children)
     }
 }
 

--- a/crates/lx/src/service/block/ir/mod.rs
+++ b/crates/lx/src/service/block/ir/mod.rs
@@ -94,7 +94,7 @@ pub enum NodeType {
     Link {
         href: String,
     },
-    /// 块引用（向后兼容，MCP 中无对应，用于 `block_quote` 映射）
+    /// 块引用（对应 Notion quote block）
     BlockQuote,
     /// Math 公式（Phase 2）
     MathBlock {
@@ -163,12 +163,6 @@ impl InlineStyle {
             && self.text_color.is_none()
             && self.background_color.is_none()
     }
-
-    /// 判断是否有任何非默认样式（兼容旧接口）
-    #[deprecated(note = "use is_plain() instead")]
-    pub fn has_any_style(&self) -> bool {
-        !self.is_plain()
-    }
 }
 
 /// 块级样式（对应 MCP `BlockStyle`）
@@ -192,8 +186,6 @@ pub struct BlockAttrs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_color: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub border_color: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<String>,
@@ -204,6 +196,9 @@ pub struct BlockAttrs {
 /// 文档树节点
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Node {
+    /// 块唯一标识符 — UUID v4 字符串（来自 Block JSON 或自动生成）
+    #[serde(default)]
+    pub id: Option<String>,
     pub node_type: NodeType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
@@ -289,6 +284,7 @@ pub struct TaskDueAt {
 impl Node {
     pub fn document(children: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Document,
             text: None,
             attrs: Default::default(),
@@ -318,6 +314,7 @@ impl Node {
 
     pub fn text(content: impl Into<String>, style: Option<InlineStyle>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Text,
             text: Some(content.into()),
             attrs: Default::default(),
@@ -361,6 +358,7 @@ impl Node {
 
     pub fn paragraph(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Paragraph,
             text: None,
             attrs: Default::default(),
@@ -391,6 +389,7 @@ impl Node {
     pub fn heading(level: u8, inlines: Vec<Node>) -> Self {
         assert!((1..=6).contains(&level));
         Self {
+            id: None,
             node_type: NodeType::Heading { level },
             text: None,
             attrs: Default::default(),
@@ -421,6 +420,7 @@ impl Node {
     /// Callout — 容器类型，内容在 children 中
     pub fn callout(color: Option<&str>, icon: Option<&str>, children: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Callout {
                 color: color.map(String::from),
                 icon: icon.map(String::from),
@@ -453,6 +453,7 @@ impl Node {
 
     pub fn quote(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::BlockQuote,
             text: None,
             attrs: Default::default(),
@@ -482,6 +483,7 @@ impl Node {
 
     pub fn bullet_item(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::BulletedList,
             text: None,
             attrs: Default::default(),
@@ -511,6 +513,7 @@ impl Node {
 
     pub fn numbered_item(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::NumberedList,
             text: None,
             attrs: Default::default(),
@@ -541,6 +544,7 @@ impl Node {
     /// Task — 支持名称和完成状态
     pub fn task(done: bool, name: impl Into<String>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Task { done, name: None },
             text: None,
             attrs: Default::default(),
@@ -570,6 +574,7 @@ impl Node {
 
     pub fn code_block(language: Option<&str>, code: &str) -> Self {
         Self {
+            id: None,
             node_type: NodeType::CodeBlock {
                 language: language.map(String::from),
             },
@@ -601,6 +606,7 @@ impl Node {
 
     pub fn divider() -> Self {
         Self {
+            id: None,
             node_type: NodeType::Divider,
             text: None,
             attrs: Default::default(),
@@ -630,6 +636,7 @@ impl Node {
 
     pub fn image(file_id: Option<&str>, caption: Option<&str>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Image {
                 file_id: file_id.map(String::from),
                 caption: caption.map(String::from),
@@ -665,6 +672,7 @@ impl Node {
 
     pub fn table(rows: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Table,
             text: None,
             attrs: Default::default(),
@@ -694,6 +702,7 @@ impl Node {
 
     pub fn table_row(cells: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::TableRow,
             text: None,
             attrs: Default::default(),
@@ -723,6 +732,7 @@ impl Node {
 
     pub fn table_cell(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::TableCell {
                 align: None,
                 background_color: None,
@@ -758,6 +768,7 @@ impl Node {
 
     pub fn column_list(columns: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::ColumnList,
             text: None,
             attrs: Default::default(),
@@ -787,6 +798,7 @@ impl Node {
 
     pub fn column(width_ratio: Option<f64>, children: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Column { width_ratio },
             text: None,
             attrs: Default::default(),
@@ -816,6 +828,7 @@ impl Node {
 
     pub fn link(href: &str, inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Link {
                 href: href.to_string(),
             },
@@ -847,6 +860,7 @@ impl Node {
 
     pub fn toggle(inlines: Vec<Node>) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Toggle,
             text: None,
             attrs: Default::default(),
@@ -876,6 +890,7 @@ impl Node {
 
     pub fn mermaid(code: &str) -> Self {
         Self {
+            id: None,
             node_type: NodeType::Mermaid {
                 content: code.to_string(),
             },
@@ -907,6 +922,7 @@ impl Node {
 
     pub fn plantuml(code: &str) -> Self {
         Self {
+            id: None,
             node_type: NodeType::PlantUml {
                 content: code.to_string(),
             },
@@ -934,6 +950,12 @@ impl Node {
             width: None,
             height: None,
         }
+    }
+
+    /// Set block ID (chainable builder-style)
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
     }
 
     pub fn plain_content(&self) -> String {

--- a/crates/lx/src/service/block/mdx/emitter.rs
+++ b/crates/lx/src/service/block/mdx/emitter.rs
@@ -4,8 +4,8 @@
 //! Output aligned with Notion Enhanced Markdown Specification:
 //! - Lowercase component tags: `<callout>`, `<details>`, `<columns>`, `<column>`, `<table>`
 //! - Block-level color via `{color="Color"}` attribute suffix
-//! - Inline styles: `<Mark bold>`, `<span underline>`, `<span color>
-//! - Quote uses native `> {color}` syntax (not mapped to callout)
+//! - Inline styles: `<Mark bold>`, `<span underline>`, `<span color>`
+//! - Quote uses native `>` syntax (not mapped to callout)
 
 #![allow(dead_code)]
 

--- a/crates/lx/src/service/block/mdx/emitter.rs
+++ b/crates/lx/src/service/block/mdx/emitter.rs
@@ -1,14 +1,39 @@
 //! `DocIR` → MDX Emitter
 //!
 //! Serializes a `DocIR` tree back to MDX text.
-//! Output follows AI Ingest Spec formatting rules:
-//! - Multi-line component syntax with 4-space indent
-//! - Double-quoted attributes
-//! - Boolean attributes without values
+//! Output aligned with Notion Enhanced Markdown Specification:
+//! - Lowercase component tags: `<callout>`, `<details>`, `<columns>`, `<column>`, `<table>`
+//! - Block-level color via `{color="Color"}` attribute suffix
+//! - Inline styles: `<Mark bold>`, `<span underline>`, `<span color>
+//! - Quote uses native `> {color}` syntax (not mapped to callout)
 
 #![allow(dead_code)]
 
 use crate::service::block::ir::{BlockAttrs, InlineStyle, Node, NodeType};
+
+/// Valid Notion block colors (text colors & background colors)
+const VALID_COLORS: &[&str] = &[
+    "gray",
+    "brown",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "purple",
+    "pink",
+    "red",
+    "gray_bg",
+    "brown_bg",
+    "orange_bg",
+    "yellow_bg",
+    "green_bg",
+    "blue_bg",
+    "purple_bg",
+    "pink_bg",
+    "red_bg",
+    "default",
+    "default_background",
+];
 
 /// Serialize a `DocIR` node to MDX text
 pub fn emit_mdx(node: &Node) -> String {
@@ -37,16 +62,28 @@ impl Emitter {
         self.output.push('\n');
     }
 
+    /// Emit `id={N}` attribute if node has a numeric-style id from original block JSON
+    fn maybe_emit_id(&mut self, node: &Node) {
+        if let Some(ref id) = node.id {
+            // Try to parse as number for numeric output; otherwise use string
+            if let Ok(num) = id.parse::<u64>() {
+                self.push(&format!(" id={{{num}}}"));
+            } else {
+                self.push(&format!(" id=\"{id}\""));
+            }
+        }
+    }
+
     fn emit_node(&mut self, node: &Node, depth: usize) {
         match &node.node_type {
             NodeType::Document => self.emit_document(node, depth),
             NodeType::Paragraph => self.emit_paragraph(node, depth),
             NodeType::Heading { level } => self.emit_heading(*level, node, depth),
-            NodeType::BlockQuote => self.emit_block_quote(node, depth),
+            NodeType::BlockQuote => self.emit_quote(node, depth),
             NodeType::Callout { color, icon } => {
                 self.emit_callout(color.as_deref(), icon.as_deref(), node, depth);
             }
-            NodeType::ColumnList => self.emit_column_list(node, depth),
+            NodeType::ColumnList => self.emit_columns(node, depth),
             NodeType::Column { width_ratio } => self.emit_column(*width_ratio, node, depth),
             NodeType::Divider => self.emit_divider(depth),
             NodeType::Image {
@@ -84,10 +121,6 @@ impl Emitter {
     }
 
     fn emit_document(&mut self, node: &Node, _depth: usize) {
-        if !self.attrs_is_empty(&node.attrs) {
-            self.emit_frontmatter(&node.attrs);
-        }
-
         for (i, child) in node.children.iter().enumerate() {
             if i > 0 {
                 self.newline();
@@ -97,10 +130,24 @@ impl Emitter {
         }
     }
 
+    /// Emit Notion block-level color attribute: `{color="Color"}`
+    /// Only emits if color is a valid Notion color name.
+    fn maybe_emit_block_color(&mut self, attrs: &BlockAttrs) {
+        if let Some(ref c) = attrs.block_color {
+            let trimmed = c.trim();
+            if !trimmed.is_empty()
+                && (VALID_COLORS.contains(&trimmed)
+                    || trimmed == "default"
+                    || trimmed.starts_with('#'))
+            {
+                self.push(&format!(" {{color=\"{trimmed}\"}}"));
+            }
+        }
+    }
+
     fn attrs_is_empty(&self, attrs: &BlockAttrs) -> bool {
         attrs.text_align.is_none()
             && attrs.block_color.is_none()
-            && attrs.border_color.is_none()
             && attrs.icon.is_none()
             && attrs.width.is_none()
             && attrs.height.is_none()
@@ -114,9 +161,6 @@ impl Emitter {
         if let Some(ref bc) = attrs.block_color {
             self.push(&format!("blockColor: {bc}\n"));
         }
-        if let Some(ref brc) = attrs.border_color {
-            self.push(&format!("borderColor: {brc}\n"));
-        }
         if let Some(ref icon) = attrs.icon {
             self.push(&format!("icon: \"{icon}\"\n"));
         }
@@ -124,33 +168,92 @@ impl Emitter {
     }
 
     fn emit_paragraph(&mut self, node: &Node, _depth: usize) {
+        self.maybe_emit_block_color(&node.attrs);
         self.emit_inline_children(&node.children);
     }
 
     fn emit_heading(&mut self, level: u8, node: &Node, _depth: usize) {
         self.push(&"#".repeat(level as usize));
         self.push(" ");
+        self.maybe_emit_block_color(&node.attrs);
         self.emit_inline_children(&node.children);
     }
 
-    fn emit_block_quote(&mut self, node: &Node, _depth: usize) {
-        let lines = self.collect_inline_lines(node);
-        for (i, line) in lines.iter().enumerate() {
-            if i > 0 {
-                self.newline();
-            }
+    /// Notion quote: `> Rich text {color="Color"}` with children
+    fn emit_quote(&mut self, node: &Node, depth: usize) {
+        // Single-line inline content → native `> text {color}` format
+        let is_simple = node
+            .children
+            .iter()
+            .all(|c| matches!(c.node_type, NodeType::Text | NodeType::Link { .. }));
+        if is_simple && !node.children.is_empty() {
+            let text_content = node
+                .children
+                .iter()
+                .map(|c| match &c.node_type {
+                    NodeType::Text => c.text.as_deref().unwrap_or("").to_string(),
+                    NodeType::Link { href } => {
+                        let inner = c
+                            .children
+                            .iter()
+                            .filter_map(|cc| cc.text.clone())
+                            .collect::<String>();
+                        format!("[{}]({href})", inner)
+                    }
+                    _ => String::new(),
+                })
+                .collect::<String>();
             self.push("> ");
-            self.push(line);
+            self.maybe_emit_block_color(&node.attrs);
+            self.push(&text_content);
+        } else if node.children.len() == 1 {
+            // Multi-line single blockquote: use <br> for line breaks
+            self.push("> ");
+            self.maybe_emit_block_color(&node.attrs);
+            let mut first = true;
+            for child in &node.children {
+                if !first {
+                    self.push("<br>");
+                }
+                first = false;
+                // Collect text content recursively into buffer
+                let mut buf = String::new();
+                self.collect_inline_to_buf(child, &mut buf);
+                self.push(&buf);
+            }
+        } else if !node.children.is_empty() {
+            // Multiple child blocks in quote: each gets its own `>` line + children indented with tab
+            for (i, child) in node.children.iter().enumerate() {
+                if i > 0 {
+                    self.newline();
+                }
+                self.push("> ");
+                self.maybe_emit_block_color(&node.attrs);
+                self.emit_node(child, depth);
+                // If this child has its own children, indent them as tab under >
+                if !child.children.is_empty() {
+                    for sub_child in &child.children {
+                        self.newline();
+                        self.push("\t");
+                        self.emit_node(sub_child, depth + 1);
+                    }
+                }
+            }
+        } else {
+            // Empty quote
+            self.push("> ");
+            self.maybe_emit_block_color(&node.attrs);
         }
     }
 
+    /// Notion callout: `<callout icon? color?>` (lowercase)
     fn emit_callout(&mut self, color: Option<&str>, icon: Option<&str>, node: &Node, depth: usize) {
-        self.push("<Callout");
+        self.push("<callout");
         if let Some(ico) = icon {
             self.push(&format!(" icon=\"{ico}\""));
         }
-        if let Some(bc) = color {
-            self.push(&format!(" borderColor=\"{bc}\""));
+        if let Some(c) = color {
+            self.push(&format!(" color=\"{c}\""));
         }
         self.push(">");
         self.newline();
@@ -161,11 +264,12 @@ impl Emitter {
             self.newline();
         }
 
-        self.push("</Callout>");
+        self.push("</callout>");
     }
 
-    fn emit_column_list(&mut self, node: &Node, depth: usize) {
-        self.push("<ColumnList>");
+    /// Notion columns: `<columns><column>...</column></columns>`
+    fn emit_columns(&mut self, node: &Node, depth: usize) {
+        self.push("<columns>");
         self.newline();
 
         for child in &node.children {
@@ -174,14 +278,12 @@ impl Emitter {
             self.newline();
         }
 
-        self.push("</ColumnList>");
+        self.push("</columns>");
     }
 
-    fn emit_column(&mut self, width_ratio: Option<f64>, node: &Node, depth: usize) {
-        match width_ratio {
-            Some(wr) => self.push(&format!("<Column width=\"{:.0}%\">", wr * 100.0)),
-            None => self.push("<Column>"),
-        }
+    /// Notion column: `<column>` — no width attribute (Notion doesn't use `width_ratio` in MDX output)
+    fn emit_column(&mut self, _width_ratio: Option<f64>, node: &Node, depth: usize) {
+        self.push("<column>");
         self.newline();
 
         for child in &node.children {
@@ -190,7 +292,7 @@ impl Emitter {
             self.newline();
         }
 
-        self.push("</Column>");
+        self.push("</column>");
     }
 
     fn emit_divider(&mut self, _depth: usize) {
@@ -212,7 +314,7 @@ impl Emitter {
     }
 
     fn emit_table(&mut self, node: &Node, depth: usize) {
-        self.push("<Table>");
+        self.push("<table>");
         self.newline();
 
         for child in &node.children {
@@ -221,11 +323,11 @@ impl Emitter {
             self.newline();
         }
 
-        self.push("</Table>");
+        self.push("</table>");
     }
 
     fn emit_table_row(&mut self, node: &Node, depth: usize) {
-        self.push("<TableRow>");
+        self.push("<tr>");
         self.newline();
 
         for child in &node.children {
@@ -234,13 +336,18 @@ impl Emitter {
             self.newline();
         }
 
-        self.push("</TableRow>");
+        self.push("</tr>");
     }
 
     fn emit_table_cell(&mut self, node: &Node, _depth: usize) {
-        self.push("<TableCell>");
+        // Check if cell has background_color from IR fields
+        let bg_color = node.cell_bg_color.as_deref();
+        match bg_color {
+            Some(color) => self.push(&format!("<td color=\"{color}\">")),
+            None => self.push("<td>"),
+        }
         self.emit_inline_children(&node.children);
-        self.push("</TableCell>");
+        self.push("</td>");
     }
 
     fn emit_todo(&mut self, done: bool, node: &Node, _depth: usize) {
@@ -289,14 +396,43 @@ impl Emitter {
     }
 
     fn emit_toggle(&mut self, node: &Node, depth: usize) {
-        self.push("<Toggle>");
+        // Notion toggle: <details color?="Color"><summary>Rich text</summary>children</details>
+        self.push("<details>");
+        if let Some(ref c) = node.attrs.block_color {
+            let trimmed = c.trim();
+            if !trimmed.is_empty() && (VALID_COLORS.contains(&trimmed) || trimmed.starts_with('#'))
+            {
+                self.push(&format!(" color=\"{trimmed}\""));
+            }
+        }
+        self.push(">\n");
+        self.push_indent(depth + 1);
+        // Summary line from first child inline text
+        let summary_text = node
+            .children
+            .first()
+            .map(super::super::ir::Node::plain_content)
+            .filter(|t| !t.is_empty());
+        match summary_text {
+            Some(text) => {
+                self.push("<summary>");
+                self.push(&text);
+                self.push("</summary>");
+            }
+            None => {
+                self.push("<summary>");
+                self.push("</summary>");
+            }
+        }
         self.newline();
-        for child in &node.children {
+
+        for child in node.children.iter().skip(1) {
             self.push_indent(depth + 1);
             self.emit_node(child, depth + 1);
             self.newline();
         }
-        self.push("</Toggle>");
+
+        self.push("</details>");
     }
 
     fn emit_mermaid(&mut self, node: &Node, _depth: usize) {
@@ -333,22 +469,67 @@ impl Emitter {
     }
 
     fn emit_styled_text(&mut self, text: &str, style: &InlineStyle) {
-        self.push("<Mark");
-        if style.bold {
-            self.push(" bold");
+        // Determine which wrapper to use
+        let has_bold_or_strike_or_code = style.bold || style.strike_through || style.inline_code;
+        let has_italic = style.italic;
+        let has_underline_or_color =
+            style.underline || style.text_color.is_some() || style.background_color.is_some();
+        let is_plain = style.is_plain();
+
+        if is_plain {
+            self.push(text);
+        } else if has_underline_or_color && !has_bold_or_strike_or_code && !has_italic {
+            // Pure span-style attributes (underline, color)
+            self.push("<span");
+            if style.underline {
+                self.push(" underline=\"true\"");
+            }
+            if let Some(ref c) = style.text_color {
+                let trimmed = c.trim();
+                if !trimmed.is_empty()
+                    && (VALID_COLORS.contains(&trimmed) || trimmed.starts_with('#'))
+                {
+                    self.push(&format!(" color=\"{trimmed}\""));
+                }
+            }
+            if let Some(ref c) = style.background_color {
+                let trimmed = c.trim();
+                if !trimmed.is_empty()
+                    && (VALID_COLORS.contains(&trimmed) || trimmed.starts_with('#'))
+                {
+                    self.push(&format!(" color=\"{trimmed}\""));
+                }
+            }
+            self.push(">");
+            self.push(text);
+            self.push("</span>");
+        } else if has_bold_or_strike_or_code || has_italic {
+            // Mark-style for bold/strike/code/italic
+            self.push("<Mark");
+            if style.bold {
+                self.push(" bold");
+            }
+            if style.italic {
+                self.push(" italic");
+            }
+            if style.strike_through {
+                self.push(" strikeThrough");
+            }
+            if style.inline_code {
+                self.push(" inlineCode");
+            }
+            self.push(">");
+            self.push(text);
+            self.push("</Mark>");
+        } else if has_italic {
+            // Pure italic only → standard markdown *text*
+            self.push("*");
+            self.push(text);
+            self.push("*");
+        } else {
+            // Underline/color only fallback
+            self.push(text);
         }
-        if style.italic {
-            self.push(" italic");
-        }
-        if style.underline {
-            self.push(" underline");
-        }
-        if style.strike_through {
-            self.push(" strikeThrough");
-        }
-        self.push(">");
-        self.push(text);
-        self.push("</Mark>");
     }
 
     fn emit_link(&mut self, href: &str, node: &Node) {
@@ -372,6 +553,28 @@ impl Emitter {
         let mut buf = String::new();
         self.collect_inline_recursive(node, &mut buf);
         vec![buf]
+    }
+
+    /// Collect inline text content into buffer for quote rendering
+    fn collect_inline_to_buf(&mut self, node: &Node, buf: &mut String) {
+        match &node.node_type {
+            NodeType::Text => {
+                buf.push_str(node.text.as_deref().unwrap_or(""));
+            }
+            NodeType::Link { href } => {
+                let text = node
+                    .children
+                    .iter()
+                    .map(super::super::ir::Node::plain_content)
+                    .collect::<String>();
+                buf.push_str(&format!("[{text}]({href})"));
+            }
+            _ => {
+                for child in &node.children {
+                    self.collect_inline_to_buf(child, buf);
+                }
+            }
+        }
     }
 
     fn collect_inline_recursive(&mut self, node: &Node, buf: &mut String) {
@@ -461,11 +664,19 @@ mod tests {
             vec![Node::paragraph(vec![Node::plain_text("Warning message")])],
         )]);
         let mdx = emit_mdx(&node);
-        assert!(mdx.contains("<Callout"));
+        // Notion format: lowercase <callout>
+        assert!(
+            mdx.contains("<callout"),
+            "expected lowercase callout, got: {mdx}"
+        );
         assert!(mdx.contains("icon=\"\u{1f6a7}\""));
-        assert!(mdx.contains("borderColor=\"red\""));
+        // Notion uses color= not borderColor=
+        assert!(mdx.contains("color=\"red\""));
         assert!(mdx.contains("Warning message"));
-        assert!(mdx.contains("</Callout>"));
+        assert!(
+            mdx.contains("</callout>"),
+            "expected </callout>, got: {mdx}"
+        );
     }
 
     #[test]
@@ -498,9 +709,16 @@ mod tests {
             italic_node,
         ])]);
         let mdx = emit_mdx(&node);
-        assert!(mdx.contains("<Mark bold>bold text</Mark>"));
+        // Bold uses <Mark bold>, italic uses <Mark italic>
+        assert!(
+            mdx.contains("<Mark bold>bold text</Mark>"),
+            "expected <Mark bold>, got: {mdx}"
+        );
         assert!(mdx.contains(" and "));
-        assert!(mdx.contains("<Mark italic>italic</Mark>"));
+        assert!(
+            mdx.contains("<Mark italic>italic</Mark>") || mdx.contains("*italic*"),
+            "expected italic format, got: {mdx}"
+        );
     }
 
     #[test]
@@ -518,18 +736,82 @@ mod tests {
         doc.attrs.text_align = Some("center".to_string());
         doc.attrs.icon = Some("\u{1f4c4}".to_string());
         let mdx = emit_mdx(&doc);
-        assert!(mdx.contains("---"));
-        assert!(mdx.contains("textAlign: center"));
-        assert!(mdx.contains("icon: \"\u{1f4c4}\""));
+        // Frontmatter is no longer emitted as YAML; block_color goes inline
+        // This test now checks that content is emitted without YAML wrapper
         assert!(mdx.contains("content"));
     }
 
     #[test]
-    fn test_roundtrip_simple() {
-        let original = "# Hello\n\nThis is **bold**.\n\n- Item one\n\n```rust\nlet x = 1;\n```";
-        let doc = crate::service::block::mdx::parser::parse_mdx(original).unwrap();
-        let emitted = emit_mdx(&doc);
-        let doc2 = crate::service::block::mdx::parser::parse_mdx(&emitted).unwrap();
-        assert_eq!(doc.children.len(), doc2.children.len());
+    fn test_emit_toggle() {
+        let node = Node::document(vec![Node::toggle(vec![
+            Node::plain_text("Click to expand"),
+            Node::paragraph(vec![Node::plain_text("Hidden content")]),
+        ])]);
+        let mdx = emit_mdx(&node);
+        // Notion format: <details><summary>Click to expand</summary>children</details>
+        assert!(mdx.contains("<details"));
+        assert!(mdx.contains("<summary>Click to expand</summary>"));
+        assert!(mdx.contains("Hidden content"));
+        assert!(mdx.contains("</details>"));
+    }
+
+    #[test]
+    fn test_emit_columns_notion() {
+        let node = Node::document(vec![Node::column_list(vec![
+            Node::column(
+                Some(0.5),
+                vec![Node::heading(2, vec![Node::plain_text("Left")])],
+            ),
+            Node::column(
+                Some(0.5),
+                vec![Node::heading(2, vec![Node::plain_text("Right")])],
+            ),
+        ])]);
+        let mdx = emit_mdx(&node);
+        // Notion format: lowercase <columns>/<column>
+        assert!(mdx.contains("<columns>"));
+        assert!(mdx.contains("</columns>"));
+        assert!(mdx.contains("<column>"));
+        assert!(mdx.contains("</column>"));
+    }
+
+    #[test]
+    fn test_emit_quote_native() {
+        // Simple quote with text children → native > format
+        let node = Node::document(vec![Node::quote(vec![Node::plain_text(
+            "A quoted message",
+        )])]);
+        let mdx = emit_mdx(&node);
+        assert!(
+            mdx.starts_with("> A quoted message"),
+            "expected native > quote, got: {mdx}"
+        );
+    }
+
+    #[test]
+    fn test_emit_block_color() {
+        // Paragraph with block_color
+        let mut p = Node::paragraph(vec![Node::plain_text("Colored text")]);
+        p.attrs.block_color = Some("blue".to_string());
+        let node = Node::document(vec![p]);
+        let mdx = emit_mdx(&node);
+        assert!(
+            mdx.contains("{color=\"blue\"}"),
+            "expected color attribute, got: {mdx}"
+        );
+        assert!(mdx.contains("Colored text"));
+    }
+
+    #[test]
+    fn test_emit_table_notion() {
+        let cell = Node::table_cell(vec![Node::plain_text("data")]);
+        let row = Node::table_row(vec![cell.clone()]);
+        let tbl = Node::table(vec![row]);
+        let mdx = emit_mdx(&tbl);
+        // Notion format: <table>/<tr>/<td>
+        assert!(mdx.contains("<table>"), "expected <table>");
+        assert!(mdx.contains("<tr>"), "expected <tr>");
+        assert!(mdx.contains("<td>data</td>"), "expected <td>");
+        assert!(mdx.contains("</table>"));
     }
 }

--- a/crates/lx/src/service/block/mdx/mod.rs
+++ b/crates/lx/src/service/block/mdx/mod.rs
@@ -1,2 +1,6 @@
 pub mod emitter;
 pub mod parser;
+
+// Re-export core functions for convenience
+pub use emitter::emit_mdx;
+pub use parser::parse_mdx;

--- a/crates/lx/src/service/block/mdx/parser.rs
+++ b/crates/lx/src/service/block/mdx/parser.rs
@@ -12,13 +12,17 @@ use crate::service::block::ir::{InlineStyle, Node, NodeType};
 /// Parse MDX text into `DocIR` Node tree
 ///
 /// Uses `ParseOptions::mdx()` + GFM extensions for full feature coverage.
+/// Supports YAML frontmatter (stripped before markdown parsing).
 pub fn parse_mdx(input: &str) -> Result<Node, ParseError> {
+    // Strip YAML frontmatter if present:  ---\n... \n---
+    let (body, _frontmatter) = strip_frontmatter(input);
+
     let mut options = markdown::ParseOptions::mdx();
     options.constructs.gfm_strikethrough = true;
     options.constructs.gfm_table = true;
     options.constructs.gfm_task_list_item = true;
 
-    let ast = markdown::to_mdast(input, &options).map_err(|msg| ParseError::AtLine {
+    let ast = markdown::to_mdast(body, &options).map_err(|msg| ParseError::AtLine {
         line: 1,
         message: msg.to_string(),
     })?;
@@ -26,6 +30,27 @@ pub fn parse_mdx(input: &str) -> Result<Node, ParseError> {
     let mut counter = 0u64;
     let children = mdast_nodes_to_ir(ast.children().unwrap_or(&vec![]), &mut counter)?;
     Ok(Node::document(children))
+}
+
+/// Strip YAML frontmatter from input text.
+///
+/// Returns (`body_without_frontmatter`, `frontmatter_content`) tuple.
+/// If no frontmatter is found, returns (`original_input`, None).
+fn strip_frontmatter(input: &str) -> (&str, Option<String>) {
+    let trimmed = input.trim_start();
+    if !trimmed.starts_with("---") {
+        return (input, None);
+    }
+
+    // Find closing ---
+    if let Some(end_pos) = trimmed[3..].find("\n---") {
+        let after_open = &trimmed[3..];
+        let fm_content = after_open[..end_pos].trim().to_string();
+        let body = &after_open[end_pos + 5..]; // skip "\n---"
+        (body.trim_start(), Some(fm_content))
+    } else {
+        (input, None)
+    }
 }
 
 // ---- Error type ----
@@ -64,18 +89,48 @@ fn mdast_nodes_to_ir(
                 let name = el.name.as_deref().unwrap_or("").to_lowercase();
                 let attrs = extract_attributes(&el.attributes);
                 let inner = mdast_nodes_to_ir(&el.children, counter)?;
+
                 match name.as_str() {
-                    "callout" => {
-                        children.push(Node::callout(
-                            attrs
-                                .get("color")
-                                .or_else(|| attrs.get("border-color"))
-                                .map(std::string::String::as_str),
-                            attrs.get("icon").map(std::string::String::as_str),
-                            inner,
-                        ));
+                    // === Notion-aligned formats ===
+                    "details" => {
+                        // Notion toggle: <details color?="Color"><summary>text</summary>children</details>
+                        let has_summary = el
+                            .children
+                            .first()
+                            .map(|c| {
+                                let t = extract_plain_text_first(c);
+                                !t.is_empty()
+                            })
+                            .unwrap_or(false);
+                        let mut toggle_node = Node::toggle(inner);
+                        if has_summary {
+                            toggle_node.children.insert(
+                                0,
+                                Node::paragraph(
+                                    mdast_inline_to_ir_fallible(&el.children).unwrap_or_default(),
+                                ),
+                            );
+                        }
+                        if let Some(c) = attrs.get("color") {
+                            toggle_node.attrs.block_color = Some(c.clone());
+                        }
+                        children.push(toggle_node);
                     }
-                    "todo" | "task" => {
+                    "callout" => {
+                        // Notion callout: <callout icon? color?>
+                        let color = attrs.get("color").map(std::string::String::as_str);
+                        let icon = attrs.get("icon").map(std::string::String::as_str);
+                        children.push(Node::callout(color, icon, inner));
+                    }
+                    "columns" => {
+                        // Notion columns: <columns><column>...</column></columns>
+                        let cols: Vec<Node> = inner
+                            .into_iter()
+                            .map(|c| Node::column(/* width_ratio */ None, vec![c]))
+                            .collect();
+                        children.push(Node::column_list(cols));
+                    }
+                    "task" => {
                         let checked = attrs
                             .get("checked")
                             .is_some_and(|v| v == "true" || v == "1");
@@ -103,23 +158,16 @@ fn mdast_nodes_to_ir(
                         task_node.temp_id = Some(Node::next_temp_id(counter));
                         children.push(task_node);
                     }
-                    "columnlist" | "column-list" => {
-                        children.push(Node::column_list(inner));
-                    }
                     "column" => {
-                        let wr = attrs
-                            .get("width")
-                            .or_else(|| attrs.get("ratio"))
-                            .or_else(|| attrs.get("width-ratio"))
-                            .and_then(|s| {
-                                s.trim_end_matches('%').trim().parse::<f64>().ok().map(|v| {
-                                    if v > 1.0 {
-                                        v / 100.0
-                                    } else {
-                                        v
-                                    }
-                                })
-                            });
+                        let wr = attrs.get("width").and_then(|s| {
+                            s.trim_end_matches('%').trim().parse::<f64>().ok().map(|v| {
+                                if v > 1.0 {
+                                    v / 100.0
+                                } else {
+                                    v
+                                }
+                            })
+                        });
                         children.push(Node::column(wr, inner));
                     }
                     "mermaid" => {
@@ -136,10 +184,6 @@ fn mdast_nodes_to_ir(
                             .collect::<String>();
                         children.push(Node::plantuml(&code));
                     }
-                    "toggle" => {
-                        let inlines = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
-                        children.push(Node::toggle(inlines));
-                    }
                     _ => {
                         // Unknown component: include inner content as children
                         children.extend(inner);
@@ -147,9 +191,12 @@ fn mdast_nodes_to_ir(
                 }
             }
             markdown::mdast::Node::Blockquote(bq) => {
-                // BlockQuote → map to Callout (our system doesn't have native Quote)
                 let inner = mdast_nodes_to_ir(&bq.children, counter)?;
-                children.push(Node::callout(None, None, inner));
+                if inner.is_empty() {
+                    children.push(Node::paragraph(vec![]));
+                } else {
+                    children.push(Node::quote(inner));
+                }
             }
             markdown::mdast::Node::List(list) => {
                 let items = mdast_list_items_to_ir(list, counter)?;
@@ -177,10 +224,7 @@ fn mdast_nodes_to_ir(
                     "callout" => {
                         let inner = mdast_nodes_to_ir(&el.children, counter)?;
                         children.push(Node::callout(
-                            attrs
-                                .get("color")
-                                .or_else(|| attrs.get("border-color"))
-                                .map(std::string::String::as_str),
+                            attrs.get("color").map(std::string::String::as_str),
                             attrs.get("icon").map(std::string::String::as_str),
                             inner,
                         ));
@@ -190,10 +234,6 @@ fn mdast_nodes_to_ir(
                             apply_style(&mut n, |s| s.bold = true);
                             result_from_children(&mut children, n);
                         }
-                    }
-                    "toggle" => {
-                        let inlines = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
-                        children.push(Node::toggle(inlines));
                     }
                     _ => {
                         let inner = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
@@ -365,52 +405,52 @@ fn mdast_inline_to_ir_fallible(nodes: &[markdown::mdast::Node]) -> Option<Vec<No
                     "callout" => {
                         let inner = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
                         result.push(Node::callout(
-                            attrs
-                                .get("color")
-                                .or_else(|| attrs.get("border-color"))
-                                .map(std::string::String::as_str),
+                            attrs.get("color").map(std::string::String::as_str),
                             attrs.get("icon").map(std::string::String::as_str),
                             inner,
                         ));
                     }
-                    "todo" | "task" => {
-                        let checked = attrs
-                            .get("checked")
-                            .is_some_and(|v| v == "true" || v == "1");
-                        let inner = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
-                        let name_val = attrs
-                            .get("name")
-                            .cloned()
-                            .or_else(|| inner.first().and_then(|n| n.text.clone()))
-                            .unwrap_or_default();
-                        let mut task_node = Node::task(checked, name_val);
-                        task_node.children = inner;
-                        result.push(task_node);
-                    }
-                    "toggle" => {
-                        let inner = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
-                        result.push(Node::toggle(inner));
-                    }
                     "column" => {
-                        let wr = attrs
-                            .get("width")
-                            .or_else(|| attrs.get("ratio"))
-                            .or_else(|| attrs.get("width-ratio"))
-                            .and_then(|s| {
-                                s.trim_end_matches('%').trim().parse::<f64>().ok().map(|v| {
-                                    if v > 1.0 {
-                                        v / 100.0
-                                    } else {
-                                        v
-                                    }
-                                })
-                            });
+                        let wr = attrs.get("width").and_then(|s| {
+                            s.trim_end_matches('%').trim().parse::<f64>().ok().map(|v| {
+                                if v > 1.0 {
+                                    v / 100.0
+                                } else {
+                                    v
+                                }
+                            })
+                        });
                         let inner = mdast_inline_to_ir_fallible(&el.children).unwrap_or_default();
                         result.push(Node::column(wr, inner));
                     }
                     "mark" => {
                         for mut n in mdast_inline_to_ir_fallible(&el.children).unwrap_or_default() {
                             apply_style(&mut n, |s| s.bold = true);
+                            result.push(n);
+                        }
+                    }
+                    "span" => {
+                        // Notion <span underline color="...">text</span>
+                        let underline = attrs
+                            .get("underline")
+                            .is_some_and(|v| v == "true" || v == "1");
+                        let color = attrs.get("color").cloned();
+                        for mut n in mdast_inline_to_ir_fallible(&el.children).unwrap_or_default() {
+                            apply_style(&mut n, |s| {
+                                if underline {
+                                    s.underline = true;
+                                }
+                                if let Some(ref c) = color {
+                                    s.text_color = Some(c.clone());
+                                    s.background_color = Some(c.clone()); // Notion span uses single color attr
+                                                                          // Clear one since we only have one field to store
+                                    if c.trim().ends_with("_bg") || c.contains("_bg") {
+                                        s.text_color = None;
+                                    } else {
+                                        s.background_color = None;
+                                    }
+                                }
+                            });
                             result.push(n);
                         }
                     }
@@ -466,6 +506,25 @@ fn extract_attributes(
 
 // ---- Helpers ----
 
+/// Extract plain text from first Text child node (for summary extraction)
+fn extract_plain_text_first(node: &markdown::mdast::Node) -> String {
+    match node {
+        markdown::mdast::Node::Paragraph(p) => p
+            .children
+            .iter()
+            .find_map(|c| match c {
+                markdown::mdast::Node::Text(t) => Some(t.value.clone()),
+                _ => None,
+            })
+            .unwrap_or_default(),
+        markdown::mdast::Node::Text(t) => t.value.clone(),
+        _ => node
+            .children()
+            .and_then(|children| children.first().map(extract_plain_text_first))
+            .unwrap_or_default(),
+    }
+}
+
 fn node_children(node: &markdown::mdast::Node) -> Vec<markdown::mdast::Node> {
     match node {
         markdown::mdast::Node::Paragraph(p) => p.children.clone(),
@@ -510,15 +569,15 @@ mod tests {
 
     #[test]
     fn test_callout_container() {
-        let mdx = r#"<Callout icon="🚧" color="red">
+        // Notion format: lowercase <callout color>
+        let mdx = r#"<callout icon="🚧" color="red">
     ## Warning
     Check before proceeding.
-</Callout>"#;
+</callout>"#;
         let doc = parse_mdx(mdx).unwrap();
         assert_eq!(doc.children.len(), 1);
         let co = &doc.children[0];
         assert!(matches!(co.node_type, NodeType::Callout { .. }));
-        // Callout should be a CONTAINER with children, not flat text
         assert!(!co.children.is_empty(), "callout must have children");
         assert_eq!(co.callout_color.as_deref(), Some("red"));
         assert_eq!(co.callout_icon.as_deref(), Some("🚧"));
@@ -596,12 +655,14 @@ mod tests {
 
     #[test]
     fn test_block_quote_maps_to_callout() {
+        // Notion: native > quotes → BlockQuote
         let doc = parse_mdx("> A quoted message").unwrap();
         assert_eq!(doc.children.len(), 1);
-        assert!(matches!(
+        assert!(
+            matches!(doc.children[0].node_type, NodeType::BlockQuote),
+            "got: {:?}",
             doc.children[0].node_type,
-            NodeType::Callout { .. }
-        ));
+        );
     }
 
     #[test]
@@ -617,22 +678,22 @@ mod tests {
 
     #[test]
     fn test_column_list() {
-        let mdx = r#"<ColumnList>
-<Column>
+        // Notion format: <columns><column>
+        let mdx = r#"<columns>
+<column>
 ### Left
 Left content
-</Column>
-<Column ratio={0.5}>
+</column>
+<column>
 ### Right
 Right content
-</Column>
-</ColumnList>"#;
+</column>
+</columns>"#;
         let doc = parse_mdx(mdx).unwrap();
         assert_eq!(doc.children.len(), 1);
         assert!(matches!(doc.children[0].node_type, NodeType::ColumnList));
         let cl = &doc.children[0];
         assert_eq!(cl.children.len(), 2);
-        assert_eq!(cl.children[1].column_width_ratio, Some(0.5));
     }
 
     #[test]
@@ -653,13 +714,15 @@ Right content
 
     #[test]
     fn test_toggle() {
-        // Single-line <Toggle> is parsed as inline JSX within a Paragraph in MDX mode
-        let mdx = "<Toggle>Click me</Toggle>";
+        // Notion toggle: <details> must be on its own line (flow element)
+        let mdx = "<details>\n<summary>Click to expand</summary>\nHidden content\n</details>";
         let doc = parse_mdx(mdx).unwrap();
         assert!(!doc.children.is_empty());
-        // Find toggle node anywhere in tree
         let toggles = doc.find_all(&NodeType::Toggle);
-        assert!(!toggles.is_empty(), "should have a Toggle node");
+        assert!(
+            !toggles.is_empty(),
+            "should have a Toggle node from <details>"
+        );
     }
 
     #[test]
@@ -692,10 +755,10 @@ Right content
 
 This document describes **MDX** converter.
 
-<Callout icon="🚧" color="red">
+<callout icon="🚧" color="red">
 ## Note
 Check before proceeding.
-</Callout>
+</callout>
 
 ## Features
 
@@ -747,5 +810,37 @@ fn hello() {}
             checked_task.unwrap().task_name.as_deref(),
             Some("Callout support")
         );
+    }
+
+    #[test]
+    fn test_frontmatter_stripped() {
+        // YAML frontmatter should be stripped, not parsed as content
+        let input = r#"---
+title: 测试文档
+author: test
+---
+
+# Real Content
+
+**bold** text
+"#;
+        let doc = parse_mdx(input).unwrap();
+
+        // Should have exactly 2 children: H1 + paragraph (NOT divider/h2 for frontmatter)
+        assert_eq!(
+            doc.children.len(),
+            2,
+            "frontmatter should produce 0 blocks, got {} children",
+            doc.children.len()
+        );
+
+        // First child should be heading
+        assert!(matches!(
+            doc.children[0].node_type,
+            NodeType::Heading { level: 1, .. }
+        ));
+
+        // Second should be paragraph with bold
+        assert!(matches!(doc.children[1].node_type, NodeType::Paragraph));
     }
 }

--- a/crates/lx/src/service/block/types.rs
+++ b/crates/lx/src/service/block/types.rs
@@ -45,7 +45,7 @@ impl BlockType {
     /// 从 MCP 返回的 type 字符串解析
     pub fn from_str(s: &str) -> Self {
         match s {
-            "paragraph" | "text" | "" => Self::Paragraph,
+            "paragraph" | "text" | "" | "p" => Self::Paragraph,
             "h1" => Self::H1,
             "h2" => Self::H2,
             "h3" => Self::H3,
@@ -55,9 +55,9 @@ impl BlockType {
             "table" => Self::Table,
             "table_row" => Self::TableRow,
             "table_cell" => Self::TableCell,
-            "bullet_list" => Self::BulletList,
+            "bullet_list" | "bulleted_list" => Self::BulletList,
             "numbered_list" => Self::NumberedList,
-            "list_item" => Self::ListItem,
+            "list_item" | "listitem" => Self::ListItem,
             "quote" | "blockquote" => Self::Quote,
             "callout" => Self::Callout,
             "toggle" => Self::Toggle,

--- a/skills/lx-block/references/mdx-reference.md
+++ b/skills/lx-block/references/mdx-reference.md
@@ -2,7 +2,7 @@
 
 > **前置条件：** 先阅读 [`../SKILL.md`](../SKILL.md) 了解 block 操作的整体决策树。
 >
-> 本文档基于 xiaokeai MCP Server 的真实 `block_create_block_descendant` schema 定义。
+> 本文档与 **Notion Enhanced Markdown Specification** 对齐。
 
 ## 概述
 
@@ -14,6 +14,12 @@ MDX（Markdown + JSX）是 AI 生成结构化内容的**推荐输入格式**。C
 AI 产出 .mdx 文件 → CLI parse_mdx() → DocIR → ir_to_descendant()
 → 完整 Block JSON（与 MCP schema 一致）→ block_create_block_descendant() 直接插入
 ```
+
+### 格式约定
+
+- **所有组件标签小写**：`<callout>`、`<columns>`、`<column>`、`<details>`、`<table>`
+- **属性双引号**：`<callout icon="🚧" color="red">`
+- **块级颜色后缀**：`{color="blue"}` 附加在任意块末尾
 
 ---
 
@@ -27,32 +33,28 @@ AI 产出 .mdx 文件 → CLI parse_mdx() → DocIR → ir_to_descendant()
 
 | block_type | MDX 语法 | content 结构 | 说明 |
 |-----------|----------|-------------|------|
-| `p` | 普通文本 | `{ elements: [TextElement[]], style?: BlockStyle }` | 默认段落 |
-| `h1` ~ `h5` | `#` ~ `#####` | `{ elements: [TextElement[]], style?: BlockStyle }` | 1-5级标题 |
-| `code` | \`\`\`language\ncode\n\`\`\` | `{ elements: [TextElement[]], style?: { language, wrap? } }` | 代码块 |
+| `p` | 普通文本 | `{ elements: [TextElement[]] }` | 默认段落 |
+| `h1` ~ `h5` | `#` ~ `#####` | `{ elements: [TextElement[]] }` | 1-5级标题 |
+| `code` | \`\`\`language\ncode\n\`\`\` | `{ language, text: "..." }` | 代码块 |
 | `divider` | `---` | `{}` | 分割线 |
 | `image` | `![alt](url)` | `{ file_id?, caption?, width?, height?, align? }` | 图片 |
-| `mermaid` | `<Mermaid>` 组件 | `{ content: "mermaid code" }` | Mermaid 图表 |
-| `plantuml` | `<PlantUml>` 组件 | `{ content: "plantuml code" }` | PlantUML 图表 |
-| `smartsheet` | `<SmartSheet>` 组件 | `{ name?, smartsheet_id? }` | 智能表格 |
-| `video` | `<Video>` 组件 | `{ file_id?, width?, height?, align? }` | 视频 |
-| `attachment` | `<Attachment>` 组件 | `{ file_id?, session_id?, view_type?, name? }` | 附件 |
+| `quote` | `> text {color}` | `{ text: { elements[] } }` | 引用块 |
 
 ### 容器块（支持 children 嵌套子块）
 
-这些块的内容通过 `children` 数组存储子块。
-
-| block_type | MDX 语法 | content 结构 | children 约束 | 说明 |
-|-----------|----------|-------------|-------------|------|
-| `callout` | `<Callout icon="🚧" color="red">...children...</Callout>` | `{ color?, icon? }` | 任意块（p/h/list/code/table 等） | **高亮提示框，内容在子块中** |
-| `toggle` | `<Toggle>标题</Toggle>` | `{ elements: [TextElement[]], style? }` | 无 | **折叠块（可展开/收起）** |
-| `task` | `- [x] 任务名` 或 `<Todo checked={true}>任务名</Todo>` | `{ name?, done, assignees?, due_at? }` | 无 | **任务（含负责人、截止时间）** |
-| `bulleted_list` | `- item` | `{ elements: [TextElement[]] }` | 无 | 无序列表 |
-| `numbered_list` | `1. item` | `{ elements: [TextElement[]] }` | 无 | 有序列表 |
-| `column_list` | `<ColumnList><Column>...</Column></ColumnList>` | `{ column_size? }` | 仅 `column` | **分栏容器** |
-| `column` | `<Column ratio={0.5}>...</Column>` | `{ width_ratio? }` | 任意块 | **分栏列（宽度比例为 number）** |
-| `table` | GFM 表格语法 | `{ column_size?, column_width[]?, header_row?, header_column?, row_size? }` | 仅 `table_cell` | **表格容器** |
-| `table_cell` | 表格单元格 | `{ align?, background_color?, col_span?, row_span?, vertical_align? }` | 任意块（通常 p） | **表格单元格** |
+| block_type | MDX 语法 | content 结构 | 说明 |
+|-----------|----------|-------------|------|
+| `callout` | `<callout icon? color?>...children...</callout>` | `{ color?, icon?, callout: true }` | 高亮提示框，内容在子块中 |
+| `toggle` | `<details color?><summary>text</summary>\nchildren\n</details>` | `{}` | 折叠块 |
+| `task` | `- [x] 任务名` 或 `<task checked name/>` | `{ done, name? }` | 任务（含完成状态） |
+| `bulleted_list` | `- item` | `{ text: { elements[] } }` | 无序列表 |
+| `numbered_list` | `1. item` | `{ text: { elements[] } }` | 有序列表 |
+| `column_list` | `<columns>\n<column>...</column>\n</columns>` | `{}` | 分栏容器 |
+| `column` | `<column>...children...</column>` | `{ width_ratio? }` | 分栏列 |
+| `table` | GFM 表格语法或 XML `<table>/<tr>/<td>` | `{ column_size?, row_size? }` | 表格容器 |
+| `table_cell` | 表格单元格内容 | `{ align?, background_color?, col_span?, row_span? }` | 表格单元格 |
+| `mermaid` | `<mermaid>\ncode\n</mermaid>` | `{ content: "..." }` | Mermaid 图表 |
+| `plantuml` | `<plantuml>\ncode\n</plantuml>` | `{ content: "..." }` | PlantUml 图表 |
 
 ---
 
@@ -63,7 +65,7 @@ AI 产出 .mdx 文件 → CLI parse_mdx() → DocIR → ir_to_descendant()
 **关键：Callout 是容器类型，实际内容存储在 `children` 子块中，不是内联文本。**
 
 ```mdx
-<Callout icon="🚧" color="red">
+<callout icon="🚧" color="red">
 ## 注意事项
 
 这是 Callout 内部的一个标题段落。
@@ -71,53 +73,48 @@ AI 产出 .mdx 文件 → CLI parse_mdx() → DocIR → ir_to_descendant()
 - 可以包含列表
 - 也可以包含代码块
 
-\`\`\`rust
+```rust
 fn example() {}
-\`\`\`
-</Callout>
 ```
 
-**对应的 Block JSON：**
-
-```json
-{
-  "block_type": "callout",
-  "block_id": "temp_callout",
-  "callout": {
-    "color": "red",
-    "icon": "🚧"
-  },
-  "children": ["temp_h2", "temp_p", "temp_list", "temp_code"],
-  "descendants": [
-    {
-      "block_id": "temp_h2",
-      "block_type": "h2",
-      "heading2": {
-        "elements": [{ "text_run": { "content": "注意事项", "text_style": {} } }]
-      },
-      "children": []
-    },
-    {
-      "block_id": "temp_p",
-      "block_type": "p",
-      "text": {
-        "elements": [{ "text_run": { "content": "这是 Callout 内部的一个标题段落。", "text_style": {} } }]
-      },
-      "children": []
-    }
-    // ... 更多子块
-  ]
-}
+</callout>
 ```
 
 | 属性 | 类型 | 说明 |
 |------|------|------|
-| `color` | String | 边框/背景颜色名 |
 | `icon` | String | Emoji 图标 |
+| `color` | String | Notion 颜色名（`red`, `blue`, `green` 等）或背景色（`red_bg` 等）|
+
+### Toggle（折叠块）
+
+Notion 格式使用 HTML `<details>` + `<summary>`：
+
+```mdx
+<details color="blue">
+<summary>点击展开查看详情</summary>
+
+这里的内容默认折叠，用户点击后展开显示。
+</details>
+```
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `color` | String | 可选的 Notion 颜色名 |
+
+### Quote（引用块）
+
+原生 Markdown 引用语法，支持块级颜色：
+
+```mdx
+> 这是一个引用消息 {color="blue"}
+
+> 多行引用
+> 第二行
+```
 
 ### Task（任务）
 
-Task 比 Todo 更丰富，支持名称、完成状态、负责人、截止时间。
+推荐使用 GFM 语法：
 
 ```mdx
 - [x] 完成接口开发
@@ -125,114 +122,41 @@ Task 比 Todo 更丰富，支持名称、完成状态、负责人、截止时间
 - [ ] 代码审查
 ```
 
-或 MDX 组件形式：
+或 MDX 组件形式（仅流级）：
 
 ```mdx
-<Todo checked={true} name="完成接口开发" assignees={["staff_001"]} due_at="2025-04-25"/>
-```
-
-**Block JSON：**
-
-```json
-{
-  "block_type": "task",
-  "block_id": "temp_task",
-  "task": {
-    "name": "完成接口开发",
-    "done": true,
-    "assignees": [{ "staff_id": "staff_001" }],
-    "due_at": { "date": "2025-04-25", "time": "18:00" }
-  },
-  "children": []
-}
+<task checked={true} name="完成接口开发"/>
 ```
 
 | 属性 | 类型 | 必填 | 说明 |
 |------|------|:----:|------|
-| `name` | String | 否 | 任务名称（也可用 elements 表示） |
-| `done` | Boolean | 是 | 是否完成 |
-| `assignees` | Array<{ staff_id }> | 否 | 负责人列表（@人） |
-| `due_at` | { date, time } | 否 | 截止时间 |
-
-### Toggle（折叠块）
-
-可展开/收起的折叠区域。
-
-```mdx
-<Toggle>
-## 点击展开查看详情
-
-这里的内容默认折叠，用户点击后展开显示。
-</Toggle>
-```
-
-**Block JSON：**
-
-```json
-{
-  "block_type": "toggle",
-  "block_id": "temp_toggle",
-  "toggle": {
-    "elements": [
-      { "text_run": { "content": "点击展开查看详情", "text_style": {} } }
-    ]
-  },
-  "children": []
-}
-```
+| `name` | String | 否 | 任务名称 |
+| `done` | Boolean | 是 | 是否完成（`true` / `1`）|
 
 ### ColumnList / Column（分栏布局）
 
 **Column 和 Callout 一样是容器类型**，分栏内容存在 children 子块中。
 
 ```mdx
-<ColumnList>
-<Column ratio={0.5}>
+<columns>
+<column>
 ### 左侧
 
 左侧内容。
-</Column>
-<Column ratio={0.5}>
+</column>
+<column>
 ### 右侧
 
 右侧内容。
-</Column>
-</ColumnList>
+</column>
+</columns>
 ```
-
-**Block JSON：**
-
-```json
-{
-  "block_type": "column_list",
-  "block_id": "temp_cl",
-  "column_list": { "column_size": 2 },
-  "children": ["temp_col1", "temp_col2"],
-  "descendants": [
-    {
-      "block_id": "temp_col1",
-      "block_type": "column",
-      "column": { "width_ratio": 0.5 },
-      "children": ["temp_h2_l", "temp_p_l"]
-    },
-    {
-      "block_id": "temp_col2",
-      "block_type": "column",
-      "column": { "width_ratio": 0.5 },
-      "children": ["temp_h2_r", "temp_p_r"]
-    }
-  ]
-}
-```
-
-| 属性 | 类型 | 说明 |
-|------|------|------|
-| `width_ratio` | Number | 宽度比例（0~1 或正数），不是百分比字符串 |
-| `column_size` | Number | 列数（需与 children 数量一致） |
 
 ### Table（表格）
 
-标准 GFM Markdown 表格语法，支持丰富的表格属性。
+支持两种格式：
+
+**GFM 语法（自动解析为 table/table_row/table_cell）：**
 
 ```mdx
 | 姓名 | 部门 | 状态 |
@@ -241,22 +165,15 @@ Task 比 Todo 更丰富，支持名称、完成状态、负责人、截止时间
 | 李四 | 产品 | 已完成 |
 ```
 
-**Block JSON（简化）：**
+**XML 格式（Notion 对齐）：**
 
-```json
-{
-  "block_type": "table",
-  "block_id": "temp_tbl",
-  "table": {
-    "column_size": 3,
-    "header_row": true,
-    "row_size": 3
-  },
-  "children": ["tc11", "tc12", "tc13", "tc21", "tc22", "tc23", "tc31", "tc32", "tc33"],
-  "descendants": [
-    // 每个 table_cell: { table_cell: { align, background_color, col_span, row_span, vertical_align }, children: [p 块] }
-  ]
-}
+```mdx
+<table>
+<tr>
+<td>A</td>
+<td>B</td>
+</tr>
+</table>
 ```
 
 ### Mermaid / PlantUML 图表
@@ -264,292 +181,221 @@ Task 比 Todo 更丰富，支持名称、完成状态、负责人、截止时间
 **一等公民类型，有独立的 content 字段存储图表代码。**
 
 ```mdx
-<Mermaid>
+<mermaid>
 graph LR
     A --> B --> C
-</Mermaid>
+</mermaid>
 
-<Plantuml>
+<plantuml>
 @startuml
 Alice -> Bob: Hello
 @enduml
-</PlantUml>
-```
-
-**Block JSON：**
-
-```json
-{
-  "block_type": "mermaid",
-  "mermaid": { "content": "graph LR\n    A --> B --> C" }
-}
-```
-
-### Image（图片）
-
-使用 `file_id` 引用已上传的图片文件。
-
-```mdx
-![图片描述](https://example.com/img.png)
-```
-
-> CLI 导入时会将 URL 转换为 file_id。直接创建时建议用 `<Image file_id="xxx">` 组件。
-
-**Block JSON：**
-
-```json
-{
-  "block_type": "image",
-  "image": {
-    "file_id": "file_xxx",
-    "caption": "图片描述",
-    "width": 800,
-    "height": 400,
-    "align": "center"
-  }
-}
+</plantuml>
 ```
 
 ---
 
-## Text / TextElement 结构（行内样式）
+## 块级颜色（Block Color）
 
-这是最核心的数据结构。所有文本块（p, h1-h5, bulleted_list, numbered_list, toggle 等）的内容都遵循此结构：
-
-```typescript
-// Block 级别的文本内容
-interface Text {
-  elements: TextElement[];        // 文本元素数组
-  style?: BlockStyle;            // 块级样式（可选）
-}
-
-// 文本元素（可以是纯文本、@人、#文档引用、日期）
-interface TextElement {
-  text_run?: {                  // 纯文本
-    content: string;             // 文本内容
-    text_style?: TextStyle;     // 行内样式
-  };
-  mention_staff?: {             // @人
-    staff_id: string;
-  };
-  mention_entry?: {             // #文档
-    entry_id: string;
-  };
-  mention_date?: {              // 日期
-    date: string;
-    time?: string;
-  };
-}
-
-// 行内样式
-interface TextStyle {
-  bold?: boolean;               // 加粗
-  italic?: boolean;              // 斜体
-  strikethrough?: boolean;       // 删除线
-  underline?: boolean;           // 下划线
-  link?: string;                // 链接 URL
-  text_color?: string;          // 文字颜色
-  background_color?: string;    // 背景颜色
-  inline_code?: boolean;         // 行内代码
-}
-
-// 块级样式
-interface BlockStyle {
-  align?: "left" | "center" | "right";   // 对齐方式
-  background_color?: string;           // 背景色
-  language?: string;                   // 代码语言（仅 code 块）
-  wrap?: boolean;                      // 自动换行（仅 code 块）
-}
-```
-
-**MDX → TextElement 映射示例：**
+**所有块都支持 Notion 颜色属性**，以 `{color="Color"}` 后缀形式追加：
 
 ```mdx
-这是 **粗体** 和 *斜体* 以及 ~~删除~~ 的组合。
-点击[这里](https://example.com)访问链接。
-`inline code` 格式。
+# 标题 {color="red"}
+
+这段文字有蓝色背景 {color="blue_bg"}
+
+> 引用文字 {color="gray"}
 ```
 
-→ 对应 `elements`:
+**有效颜色值：**
 
-```json
-[
-  { "text_run": { "content": "这是 ", "text_style": {} } },
-  { "text_run": { "content": "粗体", "text_style": { "bold": true } } },
-  { "text_run": { "content": " 和 ", "text_style": {} } },
-  { "text_run": { "content": "斜体", "text_style": { "italic": true } } },
-  { "text_run": { "content": " 以及 ", "text_style": {} } },
-  { "text_run": { "content": "删除", "text_style": { "strikethrough": true } } },
-  { "text_run": { "content": " 的组合。", "text_style": {} } },
-  { "text_run": { "content": "点击", "text_style": {} } },
-  { "text_run": { "content": "这里", "text_style": { "link": "https://example.com" } } },
-  { "text_run": { "content": "访问链接。", "text_style": {} } },
-  { "text_run": { "content": "`inline code`", "text_style": { "inline_code": true } } },
-  { "text_run": { "content": " 格式。", "text_style": {} } }
-]
+| 文字色 | 背景色 |
+|--------|--------|
+| `default` | `default_background` |
+| `gray`, `brown`, `orange`, `yellow`, `green`, `blue`, `purple`, `pink`, `red` | `gray_bg`, `brown_bg`, `orange_bg`, `yellow_bg`, `green_bg`, `blue_bg`, `purple_bg`, `pink_bg`, `red_bg` |
+
+也可使用十六进制：`{color="#FF5500"}`
+
+---
+
+## 行内样式（TextElement / TextStyle）
+
+所有文本块（p, h1-h5, bulleted_list, numbered_list 等）的内容都遵循此结构：
+
+```typescript
+// 行内元素
+interface TextElement {
+  text_run?: {
+    content: string;
+    text_style?: TextStyle;
+  };
+  mention_staff?: { staff_id: string };    // @人
+  mention_entry?: { entry_id: string };     // #文档
+  mention_date?: { date: string; time?: string }; // 日期
+}
+
+interface TextStyle {
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  underline?: boolean;
+  link?: string;
+  text_color?: string;
+  background_color?: string;
+  inline_code?: boolean;
+}
 ```
+
+### 行内样式 MDX 语法
+
+| 样式 | MDX 语法 | 输出 |
+|------|---------|------|
+| 加粗 | `**text**` 或 `<Mark bold>text</Mark>` | `text_style.bold = true` |
+| 斜体 | `*text*` 或 `<Mark italic>text</Mark>` | `text_style.italic = true` |
+| 删除线 | `~~text~~` | `text_style.strikethrough = true` |
+| 下划线 | `<span underline="true">text</span>` | `text_style.underline = true` |
+| 文字颜色 | `<span color="red">text</span>` | `text_style.text_color = "red"` |
+| 链接 | `[text](url)` | `text_style.link = url` |
+| 行内代码 | `` `code` `` | `text_style.inline_code = true` |
 
 ---
 
 ## 嵌套规则总结
 
-### 容器类型及其可包含的子块类型
-
 ```text
 Document (根)
-├── p, h1-h5, divider, image, code, mermaid, plantuml, video, attachment, smartsheet  ← 叶子节点
-├── bulleted_list, numbered_list, task, toggle                                      ← 叶子节点（无 children）
-├── callout                                                                          ← 容器：任意块
-│   ├── p, h1-h5, code, list, task, toggle, callout(嵌套), table...
-├── column_list                                                                      ← 容器：仅 column
-│   └── column                                                                         ← 容器：任意块
-│       ├── p, h1-h5, code, list, task, callout, table...
-└── table                                                                           ← 容器：仅 table_cell
-    └── table_cell                                                                     ← 容器：任意块（通常 p）
-        └── p, h1-h5, code, list...
+├── p, h1-h5, divider, image, code, quote          ← 叶子节点
+├── bulleted_list, numbered_list, task              ← 叶子节点
+├── callout                                        ← 容器：任意块
+│   ├── p, h1-h5, code, list, task, toggle, table...
+├── columns (column_list)                           ← 容器：仅 column
+│   └── column                                     ← 容器：任意块
+│       ├── p, h1-h5, code, list, task, callout...
+├── details (toggle)                                ← 容器：任意块
+│   ├── summary + children blocks
+└── table                                          ← 容器：仅 table_row
+    └── table_row                                   ← 容器：仅 table_cell
+        └── table_cell                              ← 容器：任意块
+            └── p, h1-h5, code, list...
 ```
 
-**重要约束（来自 MCP schema）：**
-
-> 以下类型为**叶子节点**，不支持 children：
-> h1, h2, h3, h4, h5（标题）、code（代码块）、image（图片）、attachment（附件）、video（视频）、divider（分割线）、mermaid（Mermaid）、plantuml（PlantUML）、smartsheet（智能表格）
+**叶子节点不支持 children：**
+h1-h5, code, image, divider, quote, bulleted_list, numbered_list, task, mermaid, plantuml
 
 ---
 
-## 完整示例：产品需求文档
+## 完整示例
 
 ```mdx
----
-title: PRD v2.0
----
-
 # 产品概述
 
 本版本重点改进**性能**和*用户体验*。
 
-<Callout icon="💡" color="blue">
+<callout icon="💡" color="blue">
 ## 设计原则
 
 1. 用户优先
 2. 向后兼容
 3. 渐进式增强
-</Callout>
+</callout>
 
-## 功能列表
-
-<Toggle>
-### 核心功能
+<details>
+<summary>核心功能</summary>
 
 - [x] Callout 组件重构
 - [x] 性能优化（首屏 < 1s）
 - [ ] 国际化支持
-</Toggle>
+</details>
 
-<ColumnList>
-<Column ratio={0.6}>
+> 重要提示：请仔细阅读以下计划 {color="orange"}
+
+<!-- markdownlint-disable MD033 -->
+<columns>
+<column>
 ### 开发计划
 
-\`\`\`typescript
+```typescript
 interface User {
   id: string;
   name: string;
 }
-\`\`\`
+```
 
+</column>
+<column>
 ### 时间线
 
 | 阶段 | 时间 | 负责人 |
 | ---- | ---- | ---- |
 | Design | W1-W2 | Alice |
 | Dev | W3-W4 | Bob |
-| QA | W5 | Carol |
-</Column>
 
-<Column ratio={0.4}>
-### 验收标准
-
-- [x] 所有 Case 通过
-- [ ] 性能达标
-- [ ] 安全审计通过
-
-<Mermaid>
+<mermaid>
 gantt
     dateFormat YYYY-MM-DD
     title 开发计划
     section 设计
     UI设计 :a1, 2025-04-01, 7d
-    API设计 :a2, after a1, 5d
     section 开发
-    前端开发 :a3, after a2, 14d
-    后端开发 :a4, after a2, 14d
-</Mermaid>
-</Column>
-</ColumnList>
-
----
-
-> **注意：** 以上数据为预估值，以实测为准。
+    前端开发 :a2, after a1, 14d
+</mermaid>
+</column>
+</columns>
+<!-- markdownlint-enable MD033 -->
 ```
 
 ---
 
 ## 组件能力完整对照表
 
-| 组件 / 特性 | 支持 | Phase | 备注 |
-|:------------|:----:|:-----:|------|
-| **文本块** ||||
-| Paragraph (`p`) | ✅ | P1 | 默认块 |
-| Heading (`h1`~`h5`) | ✅ | P1 | 1-5 级 |
-| Code (`code`) | ✅ | P1 | 带 language/wrap |
-| Divider (`divider`) | ✅ | P1 | 空结构体 |
-| Image (`image`) | ✅ | P1 | file_id + caption + size + align |
-| **结构化块** ||||
-| **Callout** | ✅ | P1 | **容器类型，color + icon，内容在 children 中** |
-| **Toggle** | ✅ | P1 | **折叠块，elements + 可选 children** |
-| **Task** | ✅ | P1 | **name + done + assignees(@人) + due_at(日期)** |
-| BulletedList | ✅ | P1 | elements 内联文本 |
-| NumberedList | ✅ | P1 | elements 内联文本 |
-| **布局块** ||||
-| **ColumnList** | ✅ | P1 | **容器，column_size + column[] 子块** |
-| **Column** | ✅ | P1 | **容器，width_ratio(number) + 任意子块** |
-| **Table** | ✅ | P1 | **容器，column_size + table_cell[] 子块** |
-| **TableCell** | ✅ | P1 | **容器，align/span/color + 任意子块** |
-| **图表** ||||
-| **Mermaid** | ✅ | P1 | **独立 { content } 结构** |
-| **PlantUML** | ✅ | P1 | **独立 { content } 结构** |
-| **多媒体** ||||
-| **Attachment** | ✅ | P1 | file_id + session_id + view_type |
-| **Video** | ✅ | P1 | file_id + size + align |
-| **SmartSheet** | ✅ | P1 | smartsheet_id，叶子节点 |
-| **行内样式** ||||
-| Bold (`**text**`) | ✅ | P1 | `text_style.bold` |
-| Italic (`*text*`) | ✅ | P1 | `text_style.italic` |
-| Strikethrough (`~~text~~`) | ✅ | P1 | `text_style.strikethrough` |
-| Underline | ✅ | P1 | `text_style.underline` |
-| Link (`[text](url)`) | ✅ | P1 | `text_style.link` |
-| Inline Code (`` ` ``) | ✅ | P1 | `text_style.inline_code` |
-| Text Color | ✅ | P1 | `text_style.text_color` |
-| Background Color | ✅ | P1 | `text_style.background_color` |
-| **@mention (@人)** | ✅ | P1 | `mention_staff: { staff_id }` |
-| **#mention (#文档)** | ✅ | P1 | `mention_entry: { entry_id }` |
-| **日期 Mention** | ✅ | P1 | `mention_date: { date, time }` |
-| **块级样式** ||||
-| Align (left/center/right) | ✅ | P1 | `style.align` |
-| Background Color | ✅ | P1 | `style.background_color` |
-| **Frontmatter** | ✅ | P1 | YAML 元数据头 |
+| 组件 / 特性 | MDX 语法 | 支持 |
+|------------|----------|:----:|
+| **文本块** |||
+| Paragraph (`p`) | 普通文本 | ✅ |
+| Heading (`h1`~`h5`) | `#` ~ `#####` | ✅ |
+| Code (`code`) | \`\`\`language\ncode\n\`\`\` | ✅ |
+| Divider (`divider`) | `---` | ✅ |
+| Image (`image`) | `![alt](url)` | ✅ |
+| Quote (`quote`) | `> text {color}` | ✅ |
+| **结构化块** |||
+| **Callout** | `<callout icon color>...</callout>` | ✅ |
+| **Toggle** | `<details><summary>...</summary></details>` | ✅ |
+| **Task** | `- [x] name` or `<task checked name/>` | ✅ |
+| BulletedList | `- item` | ✅ |
+| NumberedList | `1. item` | ✅ |
+| **布局块** |||
+| **ColumnList** | `<columns><column>...</column></columns>` | ✅ |
+| **Column** | `<column>...</column>` | ✅ |
+| **Table** | GFM `\|-\|` or `<table>/<tr>/<td>` | ✅ |
+| **TableCell** | 单元格内容（可带 `<td color>`） | ✅ |
+| **图表** |||
+| **Mermaid** | `<mermaid>code</mermaid>` | ✅ |
+| **PlantUml** | `<plantuml>code</plantuml>` | ✅ |
+| **行内样式** |||
+| Bold | `**text**` | ✅ |
+| Italic | `*text*` | ✅ |
+| Strikethrough | `~~text~~` | ✅ |
+| Underline | `<span underline="true">text</span>` | ✅ |
+| Link | `[text](url)` | ✅ |
+| Inline Code | `` `code` `` | ✅ |
+| Text Color | `<span color="red">text</span>` | ✅ |
+| **@mention (@人)** | （通过 mention_staff） | ✅ |
+| **#mention (#文档)** | （通过 mention_entry） | ✅ |
+| **块级样式** |||
+| Block Color | `{color="Color"}` 后缀 | ✅ |
 
 ---
 
 ## 格式规则速查
 
-1. **组件标签大小写不敏感**：`<Callout>` = `<callout>`
-2. **属性用双引号**：`<Callout icon="🚧">`
-3. **Callout/Column/TableCell 是容器** — 内容写在内部子块中，不是内联文本
+1. **所有组件标签小写**：`<callout>`、`<columns>`、`<column>`、`<details>`、`<table>`、`<mermaid>`、`<plantuml>`
+2. **属性用双引号**：`<callout icon="🚧" color="red">`
+3. **Callout/Column 是容器** — 内容写在内部子块中，不是内联文本
 4. **Task 用 GFM `- [x]` 语法更简洁**
-5. **Column 宽度用 `ratio={0.5}` 数字比例**（不是字符串 "50%"）
+5. **Toggle 用 `<details><summary>` HTML 语义标签**
 6. **表格必须带 header 分隔行**
-7. **Mermaid/PlantUML 使用独立 `<Component>` 标签**，内容为图表代码
-8. **叶子节点不能有 children**：h1-h5, code, image, attachment, video, divider, mermaid, plantuml, smartsheet
+7. **Mermaid/PlantUml 使用独立小写标签**：`<mermaid>`, `<plantuml>`
+8. **块级颜色统一用 `{color="Color"}` 后缀**，不是组件属性
 
 ---
 
@@ -558,3 +404,4 @@ gantt
 - [lx-block SKILL.md](../SKILL.md) — block 操作决策树
 - [block-basic.md](block-basic.md) — 原子命令
 - [block-advanced.md](block-advanced.md) — 高级命令
+- [Notion Enhanced Markdown Spec](notion://docs/enhanced-markdown-spec) — Notion MCP resource 定义


### PR DESCRIPTION
## Summary

Clean up compatibility/legacy code in the MDX pipeline (parser/emitter/adapter) after the Notion Enhanced Markdown Spec alignment work.

Closes #62

## Changes

- Remove `border_color` field and `borderColor` emission
- Remove deprecated `has_any_style()` method
- Unify block_type output to standard long names (`paragraph`, `bullet_list`, etc.)
- Delete `extract_element_legacy()` backward-compat function
- Remove dual id/block_id compatibility fields in adapter
- Update comments (remove "old chain" terminology)
- Update mdx-reference.md documentation